### PR TITLE
 Add missing surveyor legs to Tech tree

### DIFF
--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -30698,6 +30698,18 @@
     { name = ModuleTagNoResourceCostMult }
 
 }
+@PART[rn_surveyor3_legs]:FOR[xxxRP0]
+{
+    %TechRequired = matureAvionics
+    %cost = 180
+    %entryCost = 3600
+    RP0conf = true
+    @description ^=:$: <b><color=green>From RN US Probes mod</color></b>
+
+    MODULE
+    { name = ModuleTagEngineLiquidPF }
+
+}
 @PART[rn_surveyor_engines]:FOR[xxxRP0]
 {
     %TechRequired = earlyDocking


### PR DESCRIPTION
The legs of Raidernick's Surveyvor probe are currently missing completely in the tech tree. Therefore can't ever be unlocked when doing a career run.
This commit will add the missing leg part to the tech tree.

I'm not really sure about the costs and copied the values from the surveyor retro part.
We can gladly discuss the costs of the part before merging this PR.
Furthermore I'm not sure if I used the correct module tag (`ModuleTagEngineLiquidPF`). I'll be happy to correct this if it's wrong.