### PR TITLE
Corona rework

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -1546,7 +1546,7 @@
 	MODULE
 	{
 		name = ModuleAvionics
-		massLimit = 0.15
+		massLimit = 0.3
 		interplanetary = False
 	}
 }

--- a/GameData/RP-0/Parts/Science/PHOTO02-ImprovedFilmCamera.cfg
+++ b/GameData/RP-0/Parts/Science/PHOTO02-ImprovedFilmCamera.cfg
@@ -13,11 +13,10 @@
 	%RSSROConfig = True
 
 	@title = Improved Film Camera
-	@description = The Improved Film Camera is used to take photographs of Earth from space. This is a vast improvement over the very basic Early Camera. Historically, these were flown as Spy Satellites under the Corona name, but for our peaceful RP-1 purposes, these represent the earliest weather satellite photos.
-	@mass = 0.06578
+	@description = The Improved Film Camera is used to take photographs of Earth from space. This is a vast improvement over the very basic Early Camera. Historically, these were battery powered Spy Satellites under the Corona name, but for our peaceful RP-1 purposes, these represent the earliest weather satellite photos.
+	@mass = 1.0
 	@tags = science photo photographs film camera corona spy sats dmagic
 	@maxTemp = 1073.15
-	
 	!MODULE[ModuleKerbNetAccess] {}
 	!MODULE[DMReconScope] {}
 	

--- a/GameData/RP-0/Parts/Science/PHOTO02-ImprovedFilmCamera.cfg
+++ b/GameData/RP-0/Parts/Science/PHOTO02-ImprovedFilmCamera.cfg
@@ -14,7 +14,7 @@
 
 	@title = Improved Film Camera
 	@description = The Improved Film Camera is used to take photographs of Earth from space. This is a vast improvement over the very basic Early Camera. Historically, these were battery powered Spy Satellites under the Corona name, but for our peaceful RP-1 purposes, these represent the earliest weather satellite photos.
-	@mass = 1.0
+	@mass = 0.8
 	@tags = science photo photographs film camera corona spy sats dmagic
 	@maxTemp = 1073.15
 	!MODULE[ModuleKerbNetAccess] {}


### PR DESCRIPTION
This is a rework of the corona camera experiment based on research I did, outlined in issue #1344.

The camera mass has been increased to 1000kg. It's far too light as is. When built with historical tech, the masses are roughly as follows, 1000kg camera, 250kg of batteries, 250kg of avionics, return capsule, and other misc items. The goal is a total vehicle mass of about 1500kg, which is the historical mass. 

This discrepancy is for the same reason why 100 watts feels like it's too much for just a camera: It's not just a camera in there, but a "considerable" amount of 2-axis stabilization equipment. That's where all that power goes. So significant is this equipment the satellite consumes almost the same amount of power in standby compared to actively taking photos. Unfortunately this kind of equipment just isn't modeled in RP1. Not only is the near earth avionics nowhere near as heavy as this discrepancy, but the experiment has no requirement of accurately aiming the camera and taking clear photos. I can't say for sure what all that equipment is, but what I can say is it weighs about 1000kg and consumes 100 watts.

Additionally the return capsule has had it's avionics increased to 300kg, to more readily carry the return sample mass, as well as allow for the use of de-orbit motors without having to add an additional avionics core just for that.

Additional science changes are over on ROKerbalism.