### PR TITLE
Modify nuclear tag to increase realism and balance

### DIFF
--- a/GameData/RP-0/KCT/KCTTags.cfg
+++ b/GameData/RP-0/KCT/KCTTags.cfg
@@ -55,8 +55,8 @@ KCTTAGS
     TAG
     {
         name = Nuclear
-        partMult = 5
-        globalMult = 1.5
+        partMult = 6
+        globalMult = 1.05
         desc = Has radioactive elements that must be carefully handled and integrated, and require additional administrative permits.
     }
     TAG


### PR DESCRIPTION
IRL, little to no additional checks to the LV itself were required to launch a craft equipped with a nuclear reactor on it. It is also at least as safe as RTG in inert state, usually containing 11 to 50 kgs of pure, not-so-radioactive HEU-235 (Buk and Topaz, sources: https://thealphacentauri.net/75770-yadernye-incidenty-kosmos-954-i-1402/ ; https://ru.wikipedia.org/wiki/%D0%AF%D0%B4%D0%B5%D1%80%D0%BD%D1%8B%D0%B5_%D1%80%D0%B5%D0%B0%D0%BA%D1%82%D0%BE%D1%80%D1%8B_%D0%BD%D0%B0_%D0%BA%D0%BE%D1%81%D0%BC%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%B8%D1%85_%D0%B0%D0%BF%D0%BF%D0%B0%D1%80%D0%B0%D1%82%D0%B0%D1%85 ), and usually is first started only when reaching orbit. In addition, space-grade nuclear reactors have historically been equipped (at least in the USSR) with a robust body capable of surviving a launch vehicle accident intact, which also reduces the requirements for the rocket as a whole. This was proved by the accident of the Cyclone-2 launch vehicle on April 25, 1973 (source: http://www.cosmoworld.ru/spaceencyclopedia/chrono/index.shtml?1973.html . Could be considered as reliable as the encyclopedia is created by a known space expert: https://ru.wikipedia.org/wiki/%D0%96%D0%B5%D0%BB%D0%B5%D0%B7%D0%BD%D1%8F%D0%BA%D0%BE%D0%B2,_%D0%90%D0%BB%D0%B5%D0%BA%D1%81%D0%B0%D0%BD%D0%B4%D1%80_%D0%91%D0%BE%D1%80%D0%B8%D1%81%D0%BE%D0%B2%D0%B8%D1%87 ).

However, looking at the requirements for the reactor itself, its transportation and safety ( https://cdn.discordapp.com/attachments/620690446540341261/1102336673662111774/bbca7fa006698e9d.txt ), it can be concluded that everything is much more complicated (and more expensive) on the side of the reactor itself, requiring repeated testing and careful integration of the product. At the same time, the aformentioned document baely requirres anything from the rocket itself, except the launch of a spacecraft with a nuclear reactor on board was allowed only on LVs that had repeatedly proven their overall reliability (similar to the DoD sertification in the United States) and some radiological protection measures on launchsite.

In addition, from the point of view of balance, the 1.5 multiplier also looks too punishing, especially for large rockets, which is why almost no one uses reactors and nuclear engines within the framework of RP-0. As of now there is absolutely zero reason to use reactors or NTRs at all, since any number of solars or absurd chemical engine clusters would be cheaper than 1.5x increase to an entire stack price.

Based on all of the above, I propose to almost completely remove the global modifier (the remaining .05 fall on radiological protection measures, military security and bureaucracy with UN notification), but also slightly raise the cost multiplier as underestimating the full amount of testing required to guarantee the reliability and safety of the core once actually in orbit.

P.S. All sources are given in Russian, because the USSR was the only country that actively and constantly used devices with nuclear reactors on board, so their practice and regulation seem to me the most applicable.
P.S. 2. It is also worth considering that at that time regulation was probably much simpler (although I can't find documents that could confirm this). The main scope of the game takes place from the 1950s to the 1980s, when people did not consider, for example, testing a nuclear engine with fuel element fragments flying in all directions as something abnormal.