### PR TITLE
HasCompleted vessel parameter and RP1ContractTracker

### DIFF
--- a/Source/CC_RP0/CC_RP0.csproj
+++ b/Source/CC_RP0/CC_RP0.csproj
@@ -61,6 +61,8 @@
     <Compile Include="AvionicsCheckFactory.cs" />
     <Compile Include="ContractClobberer.cs" />
     <Compile Include="CustomExpressionParserRegistrer.cs" />
+    <Compile Include="HasCompleted.cs" />
+    <Compile Include="HasCompletedFactory.cs" />
     <Compile Include="RP1CollectScience.cs" />
     <Compile Include="RP1CollectScienceFactory.cs" />
     <Compile Include="DownrangeDistanceFactory.cs" />
@@ -68,6 +70,7 @@
     <Compile Include="HorizontalLandingFactory.cs" />
     <Compile Include="HorizontalLandingVesselParam.cs" />
     <Compile Include="ProgramActiveRequirement.cs" />
+    <Compile Include="RP1ContractTracker.cs" />
     <Compile Include="RP1RendezvousFactory.cs" />
     <Compile Include="RP1RendezvousVesselParam.cs" />
     <Compile Include="ImpactCBFactory.cs" />

--- a/Source/CC_RP0/HasCompleted.cs
+++ b/Source/CC_RP0/HasCompleted.cs
@@ -1,0 +1,109 @@
+﻿
+using System.Collections.Generic;
+using System.Linq;
+using System;
+using Contracts;
+using ContractConfigurator.Parameters;
+using KerbalConstructionTime;
+using UnityEngine;
+
+namespace ContractConfigurator.RP0
+{
+    /// <summary>
+    /// Parameter for checking that a vessel has not completed other contracts.
+    /// </summary>
+    public class HasCompleted : VesselParameter
+    {
+        protected List<string> ContractTags { get; set; }
+        protected bool InvertParameter = false;
+
+        public HasCompleted()
+            : base(null)
+        {
+        }
+
+        public HasCompleted(List<string> contractTags, bool invertParameter, string title)
+            : base(title)
+        {
+            this.ContractTags = contractTags;
+            this.InvertParameter = invertParameter;
+        }
+
+        protected override string GetParameterTitle()
+        {
+            return string.IsNullOrEmpty(title) ? $"Has {(InvertParameter ? "Not " : "")}Completed Other Contracts" : title;
+        }
+
+        protected override void OnParameterSave(ConfigNode node)
+        {
+            base.OnParameterSave(node);
+            foreach (string ct in ContractTags)
+            {
+                node.AddValue("contractTag", ct);
+            }
+            node.AddValue("invertParameter", InvertParameter);
+        }
+
+        protected override void OnParameterLoad(ConfigNode node)
+        {
+            base.OnParameterLoad(node);
+            ContractTags = ConfigNodeUtil.ParseValue<List<string>>(node, "contractTag", new List<string>());
+            InvertParameter = Convert.ToBoolean(node.GetValue("invertParameter"));
+        }
+
+        protected override void OnRegister()
+        {
+            GameEvents.Contract.onCompleted.Add(OnContractCompleted);
+            CheckTargetVessel();
+            base.OnRegister();
+        }
+
+        protected override void OnUnregister()
+        {
+            GameEvents.Contract.onCompleted.Remove(OnContractCompleted);
+            base.OnUnregister();
+        }
+
+        protected void OnContractCompleted(Contract c)
+        {
+            CheckTargetVessel();
+        }
+
+        private void CheckTargetVessel()
+        {
+            VesselParameterGroup vpg = InVPG(this);
+            CheckVessel(vpg?.TrackedVessel ?? FlightGlobals.ActiveVessel);
+        }
+
+        public void CheckVPGVessel(Vessel v)
+        {
+            CheckVessel(v);
+        }
+
+        // Return enclosing VPG for this parmameter if it exists
+        protected VesselParameterGroup InVPG(IContractParameterHost node)
+        {
+            if (node == Root)
+                return null;
+            if (node.Parent is VesselParameterGroup vpg)
+                return vpg;
+            else
+                return InVPG(node.Parent);
+        }
+
+        /// <summary>
+        /// Whether this vessel meets the parameter condition.
+        /// </summary>
+        /// <param name="vessel">The vessel to check</param>
+        /// <returns>Whether the vessel meets the condition</returns>
+        protected override bool VesselMeetsCondition(Vessel vessel)
+        {
+            LoggingUtil.LogVerbose(this, "Checking VesselMeetsCondition: {0}", vessel.id);
+
+            bool result = RP1ContractTracker.Instance.ContractTracker.TryGetValue(vessel.GetKCTVesselId(), out List<RP1ContractTracker.ContractInfo> contracts) && 
+                          contracts.Select(x => x.Name).ToList().Intersect(ContractTags).Any();
+
+            return InvertParameter ^ result;
+        }
+    }
+}

--- a/Source/CC_RP0/HasCompletedFactory.cs
+++ b/Source/CC_RP0/HasCompletedFactory.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using Contracts;
+
+
+namespace ContractConfigurator.RP0
+{
+    /// <summary>
+    /// ParameterFactory wrapper for HasCompletedFactory ContractParameter. 
+    /// </summary>
+    public class HasCompletedFactory : ParameterFactory
+    {
+        protected List<string> contractTags = new List<string>();
+        protected bool invertParameter;
+
+        public override bool Load(ConfigNode configNode)
+        {
+            // Load base class
+            bool valid = base.Load(configNode);
+
+            valid &= ConfigNodeUtil.ParseValue<List<string>>(configNode, "contractTag", x => contractTags = x, this);
+            valid &= ConfigNodeUtil.ParseValue<bool>(configNode, "invertParameter", x => invertParameter = x, this, false);
+
+            return valid;
+        }
+
+        public override ContractParameter Generate(Contract contract)
+        {
+            return new HasCompleted(contractTags, invertParameter, title);
+        }
+    }
+}

--- a/Source/CC_RP0/RP1ContractTracker.cs
+++ b/Source/CC_RP0/RP1ContractTracker.cs
@@ -1,0 +1,160 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Contracts;
+using ContractConfigurator.Parameters;
+using KerbalConstructionTime;
+using RP0;
+
+namespace ContractConfigurator.RP0
+{
+    /// <summary>
+    /// Class for tracking contracts completed by a KCT vessel.
+    /// </summary>
+    [KSPScenario(ScenarioCreationOptions.AddToExistingCareerGames | ScenarioCreationOptions.AddToNewCareerGames,
+        GameScenes.FLIGHT, GameScenes.TRACKSTATION, GameScenes.SPACECENTER)]
+    public class RP1ContractTracker : ScenarioModule
+    {
+        static public RP1ContractTracker Instance { get; private set; }
+        [Persistent] public Dictionary<string, List<ContractInfo>> ContractTracker;
+
+        public class ContractInfo
+        {
+            public string Name;
+            public double CompletionTime;
+        }
+
+
+        public RP1ContractTracker()
+        {
+             if (ContractTracker == null)
+             {
+                ContractTracker = new Dictionary<string, List<ContractInfo>>();
+             }
+            Instance = this;
+        }
+
+        protected void Start()
+        {
+            GameEvents.Contract.onCompleted.Add(OnContractCompleted);
+        }
+
+        protected void OnDestroy()
+        {
+            GameEvents.Contract.onCompleted.Remove(OnContractCompleted);
+        }
+
+        protected void OnContractCompleted(Contract c)
+        {
+            if ((c is ConfiguredContract cc))  //note: Only vessels in VPGs are tracked currently
+            {
+                foreach (VesselParameterGroup vpg in cc.GetChildren().Where(x => x is VesselParameterGroup))
+                {
+                    Vessel trackedVessel = vpg.TrackedVessel;
+                    if (trackedVessel != null)
+                    {
+                        if (!string.IsNullOrEmpty(cc.contractType.tag))
+                            AddToContractTracker(trackedVessel, cc.contractType.tag);
+
+                        AddToContractTracker(trackedVessel, cc.contractType.name);
+                        CheckClosedVPGs(cc, trackedVessel);
+                    }
+                }
+            }
+        }
+
+        private void CheckClosedVPGs(ConfiguredContract cc, Vessel trackedVessel)
+        {
+            foreach (ConfiguredContract activeContract in ConfiguredContract.ActiveContracts)
+            {
+                if (cc != activeContract)
+                {
+                    foreach (VesselParameterGroup vpg in activeContract.GetChildren().Where(x => x is VesselParameterGroup))
+                    {
+                        if (vpg.TrackedVessel.GetKCTVesselId() == trackedVessel.GetKCTVesselId())
+                            CheckVPG(vpg);
+                    }
+                }
+            }
+
+        }
+
+        private void AddToContractTracker(Vessel v, string contract)
+        {
+            List<ContractInfo> contracts;
+            string vesselID = v.GetKCTVesselId();
+
+            if (vesselID == null)
+                return;
+
+            ContractInfo item = new ContractInfo
+            {
+                Name = contract,
+                CompletionTime = KSPUtils.GetUT()
+            };
+
+            if (ContractTracker.TryGetValue(vesselID,out contracts))
+            {
+                contracts.Add(item);
+            }
+            else
+            {
+                contracts = new List<ContractInfo> { item };
+                ContractTracker.Add(v.GetKCTVesselId(), contracts);
+            }
+        }
+        public override void OnLoad(ConfigNode node)
+        {
+            base.OnLoad(node);
+            ContractTracker.Clear();
+
+            foreach (ConfigNode keyNode in node.GetNodes())
+            {
+                string keyName = keyNode.name;
+                List<ContractInfo> contracts = new List<ContractInfo>();
+
+                foreach (ConfigNode contractNode in keyNode.GetNodes("Contract"))
+                {
+                    ContractInfo contract = new ContractInfo();
+                    contractNode.TryGetValue("Name", ref contract.Name);
+                    contractNode.TryGetValue("CompletionTime", ref contract.CompletionTime);
+                    contracts.Add(contract);
+                }
+
+                ContractTracker.Add(keyName, contracts);
+            }
+        }
+        public override void OnSave(ConfigNode node)
+        {
+           base.OnSave(node);
+           foreach (KeyValuePair<string,List<ContractInfo>> vesselID in ContractTracker)
+            {
+                ConfigNode keyNode = node.AddNode(vesselID.Key);
+                foreach (ContractInfo contract in vesselID.Value)
+                {
+                    ConfigNode contractNode = keyNode.AddNode("Contract");
+                    contractNode.AddValue("Name", contract.Name);
+                    contractNode.AddValue("CompletionTime", contract.CompletionTime);
+                }
+            }
+        }
+
+        private void CheckVPG(VesselParameterGroup vpg)
+        {
+            if (vpg.TrackedVessel == null)
+                return;
+
+            foreach (HasCompleted param in vpg.GetAllDescendents().Where(x => x is HasCompleted))
+            {
+                param.Enable();
+                param.CheckVPGVessel(vpg.TrackedVessel);
+
+                if (!vpg.Enabled) {
+                    vpg.Enable();
+                    vpg.SetState(ParameterState.Incomplete);
+                    vpg.Enable();   // Ugh, don't ask why
+                    vpg.Reset();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add RP1ContractTracker scenario module. Tracks configured contract completions per KCTVesselID. Contract tag used if available, otherwise name.  UT of each completion is also stored.

Add HasCompleted vessel parameter. Checks RP1ContractTracker for contracts already completed by KCTVesselID, either current or in tracked/unloaded VPG. Invertible. Multiple contract tags allowed, results ORed.

Example syntax:
		PARAMETER
		{
			name = ExclusiveLaunch
			type = HasCompleted
			title = Do Not Complete Other Accepted Contracts
			invertParameter = true
			contractTag = distance_SoundingRocket
			contractTag = alt_SoundingRocket
			contractTag = other_SoundingRocket
			contractTag = exclude_EarlySatellite
		}