### PR TITLE
Reduce cost of first admin building upgrade

### DIFF
--- a/GameData/RP-1/CustomBarnKit.cfg
+++ b/GameData/RP-1/CustomBarnKit.cfg
@@ -47,7 +47,7 @@
 	}
 	@ASTRONAUTS
 	{
-		@upgrades = 100000, 500000, 1500000
+		@upgrades = 50000, 500000, 1500000
 		
 		@recruitHireBaseCost = 5000
 		@recruitHireFlatRate = 1.25
@@ -92,7 +92,7 @@
 	{
 		@levels = 3
 		@upgradesVisual = 1, 2, 3
-		@upgrades = 25000, 250000, 750000
+		@upgrades = 25000, 150000, 750000
 		@activeStrategyLimit = 2, 3, 4
 		@strategyCommitRange = 0, 0, 0
 	}


### PR DESCRIPTION
I also reduced the cost of the level one astronaut complex which will halve the maintenance cost from ~7200/year to ~3600/year, which is more in line with other buildings. As this is the level 1 version, it won't effect upgrade prices.
