### PR TITLE
Fix Mars/Venus orbiter contracts confidence

### DIFF
--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -687,6 +687,7 @@ RP0_PROGRAM
 		landingPhobos = true
 		probeMars = true
 		samplesPhobos = true
+		MarsOrbitRepeatable = true
 	}
 	
 }
@@ -724,6 +725,7 @@ RP0_PROGRAM
 	OPTIONALS
 	{
 		probeVenus = true
+		VenusOrbitRepeatable = true
 	}
 }
 


### PR DESCRIPTION
When under Mars/Venus surface exploration programs, these optional repeatable contracts (originally present in the Early Inner Solar System Probes program) were available, but were missing confidence.

There are probably other contracts like these broken in the same way, and as more optional contracts are added we should be careful not to miss adding them to the appropriate lists.