### PR TITLE
Xplane retuning and ss optional changes

### DIFF
--- a/GameData/RP-1/Contracts/X-Plane Research/RocketPlaneDevelopment.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/RocketPlaneDevelopment.cfg
@@ -33,7 +33,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 10
+	rewardReputation = 15
 	failureReputation = 10
 	
 	// ************ REQUIREMENTS ************

--- a/GameData/RP-1/Contracts/X-Plane Research/RocketPlaneDevelopmentOptional.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/RocketPlaneDevelopmentOptional.cfg
@@ -33,7 +33,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = Round(10 * @rewardFactor, 1)
+	rewardReputation = Round(15 * @rewardFactor, 1)
 	failureReputation = 10
 	
 	DATA

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesHighAltitude.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesHighAltitude.cfg
@@ -33,7 +33,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 10
+	rewardReputation = 15
 	failureReputation = @rewardReputation
 
 	DATA

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesHighAltitudeOptional.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesHighAltitudeOptional.cfg
@@ -33,7 +33,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 10
+	rewardReputation = 15
 	failureReputation = @rewardReputation
 
 	DATA

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesKarman.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesKarman.cfg
@@ -32,7 +32,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 10
+	rewardReputation = 25
 	failureReputation = @rewardReputation
 	
 	// ************* REQUIREMENTS ****************

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesSuborbital.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesSuborbital.cfg
@@ -33,7 +33,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = Round(10 * @rewardFactor, 1)
+	rewardReputation = Round(30 * @rewardFactor, 1)
 	failureReputation = @rewardReputation
 
 	DATA

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicMach2.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicMach2.cfg
@@ -4,8 +4,10 @@ CONTRACT_TYPE
 	group = EarlyXPlanes
 
 	title = X-Planes (Mach 2 Supersonic)
+	
+	tag = exclude_Supersonic
 
-	description = <b>Program: X-Plane Research<br>Type: <color=green>Required</color></b><br><br>Design, build, and fly a crewed jet aircraft to maintain @VesselGroup/HoldSituation/minSpeed m/s in level flight, then return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.<br><br><color=white><b>After this contract has been completed, the 'X-Planes (High Supersonic)' contract will become available.</b></color>
+	description = <b>Program: X-Plane Research<br>Type: <color=green>Required</color></b><br><br>Design, build, and fly a crewed jet aircraft to maintain @VesselGroup/HoldSituation/minSpeed m/s in level flight, then return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.<br><br><color=white><b>After this contract has been completed, the 'X-Planes (Supersonic) Optional' contracts will become available.</b></color>
 	genericDescription = Design, build, and fly a crewed jet aircraft to maintain a specific speed in level flight, then return home safely.
 
 	synopsis = Fly a crewed jet aircraft to maintain @VesselGroup/HoldSituation/minSpeed m/s in level flight and hold, then return safely.
@@ -33,7 +35,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 15
+	rewardReputation = 25
 	failureReputation = @rewardReputation
 	
 	// ************* REQUIREMENTS ****************
@@ -49,8 +51,16 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		minCount = 2
+		minCount = 1
 		contractType = XPlanesSupersonic
+	}
+	
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		tag = exclude_Supersonic
+		invertRequirement = true
 	}
 
 	BEHAVIOUR
@@ -62,9 +72,11 @@ CONTRACT_TYPE
 		{
 			XPSS_Completion = ($XPSS_Completion + 0) == 0 ? (UniversalTime() - 120 * 86400) : ($XPSS_Completion + 0)
 		}
+		
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			XPSS_Completion = UniversalTime()
+			RP0_XPSS_Difficulty = 7
 		}
 	}
 

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicOptionalHigh.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicOptionalHigh.cfg
@@ -1,21 +1,20 @@
 CONTRACT_TYPE
 {
-	name = XPlanesSupersonic
+	name = XPlanesSupersonicOptionalHigh
 	group = EarlyXPlanes
 
-	title = X-Planes (Supersonic)
+	title = X-Planes (High Supersonic) Optional
 	
 	tag = exclude_Supersonic
 
-	description = <b>Program: X-Plane Research<br>Type: <color=green>Required</color></b><br><br>Design, build, and fly a crewed jet aircraft to maintain @VesselGroup/HoldSituation/minSpeed m/s in level flight, then return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.<br><b>After completion, the 'X-Planes (Mach 2 Supersonic)' contract will become available.</b></color> <br><color=white><br><b>After this contract has been completed, more 'X-Planes (Supersonic) Optional' contracts will become available.</b></color>
-	
-	genericDescription = Design, build and fly a crewed jet aircraft to maintain a specific speed in level flight, then return home safely.
+	description = <b>Program: X-Plane Research<br>Type: <color=blue>Optional</color></b><br><br>Design, build, and fly a crewed jet aircraft to maintain @VesselGroup/HoldSituation/minSpeed m/s in level flight, then return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.<br><br>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.<br><b>Current reward is at @rewardFactorPercent % of its nominal value. Elapsed/Expected Days: @elapsedDays / @RP0:expectedDays_XPlanesSupersonicOptional</b><br><br>This is a series of @maxCompletions contracts, of which @completions have been completed.
+	genericDescription = Design, build, and fly a crewed jet aircraft to maintain a specific speed in level flight, then return home safely.
 
 	synopsis = Fly a crewed jet aircraft to maintain @VesselGroup/HoldSituation/minSpeed m/s in level flight and hold, then return safely.
 
 	completedMessage = Congratulations on a successful flight!
 	
-	sortKey = 601
+	sortKey = 603
 
 	deadline = 0
 	cancellable = true
@@ -26,7 +25,7 @@ CONTRACT_TYPE
 
 	targetBody = HomeWorld()
 
-	maxCompletions = 1
+	maxCompletions = 12
 	maxSimultaneous = 1
 	prestige = Trivial
 
@@ -36,13 +35,28 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 15
+	rewardReputation = Round(25 * @rewardFactor, 1)
 	failureReputation = @rewardReputation
 	
 	DATA
 	{
 		type = int
-		index = $RP0_XPSS_Difficulty + 0
+		antiGrindCompletion = $XPSS_Completion == 0 ? (UniversalTime() - @RP0:expectedDays_XPlanesSupersonicOptional * 86400) : $XPSS_Completion
+	}
+	
+	DATA
+	{
+		type = int
+		index = $RP0_XPSS_High_Difficulty
+		completions = $RP0_XPSS_High_Difficulty
+	}
+
+	DATA
+	{
+		type = float
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @RP0:expectedDays_XPlanesSupersonicOptional * 20 - 9, 1), 2) / 3.46
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
 	}
 	
 	// ************* REQUIREMENTS ****************
@@ -58,7 +72,7 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = BreakSoundBarrier
+		contractType = XPlanesSupersonicMach2
 	}
 	
 	REQUIREMENT
@@ -68,18 +82,43 @@ CONTRACT_TYPE
 		tag = exclude_Supersonic
 		invertRequirement = true
 	}
-
+	
 	BEHAVIOUR
 	{
-		name = IncrementTheCount
+		name = IncrementTheCount 
 		type = Expression
 
+		CONTRACT_OFFERED
+		{
+			
+			XPSS_Completion = ($XPSS_Completion + 0) == 0 ? (UniversalTime() - @RP0:expectedDays_XPlanesSupersonicOptional * 86400) : ($XPSS_Completion + 0)
+		
+		}
+		
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			XPSS_Completion = UniversalTime()
-			RP0_XPSS_Difficulty = 4
 		}
 	}
+	
+	BEHAVIOUR
+	{
+		name = SetSSDifficulty
+		type = Expression
+
+
+		CONTRACT_COMPLETED_SUCCESS
+		{
+			RP0_XPSS_High_Difficulty = $RP0_XPSS_High_Difficulty + 1
+		}
+	}
+	
+	DATA
+	{
+		type = List<float>
+		minSpeedKMH = [ 650, 700, 750, 800, 850, 900, 950, 1000, 1050, 1100, 1150, 1200]
+	}
+	
 
 	PARAMETER
 	{
@@ -117,8 +156,8 @@ CONTRACT_TYPE
 		{
 			name = HoldSituation
 			type = ReachState
-			minSpeed = 450
-			maxSpeed = 475
+			minSpeed = @/minSpeedKMH.ElementAt(@/index)
+			maxSpeed = @/minSpeedKMH.ElementAt(@/index) + 25
 			minRateOfClimb = -10
 			maxRateOfClimb = 10
 			situation = FLYING
@@ -131,7 +170,7 @@ CONTRACT_TYPE
 			{
 				name = Duration
 				type = Duration
-				duration = 5m
+				duration = 3m
 				preWaitText = Reach specified speed.
 				waitingText = Testing highspeed flight
 				completionText = Flight completed, you are cleared to land.

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicOptionalLow.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicOptionalLow.cfg
@@ -1,9 +1,11 @@
 CONTRACT_TYPE
 {
-	name = XPlanesSupersonicOptional
+	name = XPlanesSupersonicOptionalLow
 	group = EarlyXPlanes
 
-	title = X-Planes (High Supersonic)
+	title = X-Planes (Low Supersonic) Optional
+	
+	tag = exclude_Supersonic
 
 	description = <b>Program: X-Plane Research<br>Type: <color=blue>Optional</color></b><br><br>Design, build, and fly a crewed jet aircraft to maintain @VesselGroup/HoldSituation/minSpeed m/s in level flight, then return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.<br><br>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.<br><b>Current reward is at @rewardFactorPercent % of its nominal value. Elapsed/Expected Days: @elapsedDays / @RP0:expectedDays_XPlanesSupersonicOptional</b><br><br>This is a series of @maxCompletions contracts, of which @completions have been completed.
 	genericDescription = Design, build, and fly a crewed jet aircraft to maintain a specific speed in level flight, then return home safely.
@@ -23,7 +25,7 @@ CONTRACT_TYPE
 
 	targetBody = HomeWorld()
 
-	maxCompletions = 11
+	maxCompletions = 2
 	maxSimultaneous = 1
 	prestige = Trivial
 
@@ -33,7 +35,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = Round(18 * @rewardFactor, 1)
+	rewardReputation = Round(12 * @rewardFactor, 1)
 	failureReputation = @rewardReputation
 	
 	DATA
@@ -45,8 +47,8 @@ CONTRACT_TYPE
 	DATA
 	{
 		type = int
-		index = $RP0_XPSS_Difficulty
-		completions = $RP0_XPSS_Difficulty - 2
+		index = $RP0_XPSS_Low_Difficulty
+		completions = $RP0_XPSS_Low_Difficulty
 	}
 
 	DATA
@@ -70,24 +72,62 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = XPlanesSupersonicMach2
+		contractType = BreakSoundBarrier
 	}
+	
 
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = XPlanesSupersonic
+		invertRequirement  = true
+	}
+	
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		tag = exclude_Supersonic
+		invertRequirement = true
+	}
+	
 	BEHAVIOUR
 	{
-		name = IncrementTheCount
+		name = IncrementTheCount 
 		type = Expression
 
 		CONTRACT_OFFERED
 		{
+			
 			XPSS_Completion = ($XPSS_Completion + 0) == 0 ? (UniversalTime() - @RP0:expectedDays_XPlanesSupersonicOptional * 86400) : ($XPSS_Completion + 0)
+		
 		}
+		
 		CONTRACT_COMPLETED_SUCCESS
 		{
-			RP0_XPSS_Difficulty = $RP0_XPSS_Difficulty + 1
 			XPSS_Completion = UniversalTime()
 		}
 	}
+	
+	BEHAVIOUR
+	{
+		name = SetSSDifficulty
+		type = Expression
+
+
+		CONTRACT_COMPLETED_SUCCESS
+		{
+			RP0_XPSS_Low_Difficulty = $RP0_XPSS_Low_Difficulty + 1
+		}
+	}
+	
+	DATA
+	{
+		type = List<float>
+		minSpeedKMH = [ 350, 400]
+	}
+	
 
 	PARAMETER
 	{
@@ -125,8 +165,8 @@ CONTRACT_TYPE
 		{
 			name = HoldSituation
 			type = ReachState
-			minSpeed = $RP0_XPSS_Difficulty <= 4 ? ($RP0_XPSS_Difficulty * 50 + 600) : ($RP0_XPSS_Difficulty * 100 + 400)
-			maxSpeed = $RP0_XPSS_Difficulty <= 4 ? ($RP0_XPSS_Difficulty * 50 + 625) : ($RP0_XPSS_Difficulty * 100 + 450)
+			minSpeed = @/minSpeedKMH.ElementAt(@/index)
+			maxSpeed = @/minSpeedKMH.ElementAt(@/index) + 25
 			minRateOfClimb = -10
 			maxRateOfClimb = 10
 			situation = FLYING
@@ -139,7 +179,7 @@ CONTRACT_TYPE
 			{
 				name = Duration
 				type = Duration
-				duration = 5m
+				duration = 3m
 				preWaitText = Reach specified speed.
 				waitingText = Testing highspeed flight
 				completionText = Flight completed, you are cleared to land.

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicOptionalMid.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicOptionalMid.cfg
@@ -1,21 +1,20 @@
 CONTRACT_TYPE
 {
-	name = XPlanesSupersonic
+	name = XPlanesSupersonicOptionalMid
 	group = EarlyXPlanes
 
-	title = X-Planes (Supersonic)
+	title = X-Planes (Mid Supersonic) Optional
 	
 	tag = exclude_Supersonic
 
-	description = <b>Program: X-Plane Research<br>Type: <color=green>Required</color></b><br><br>Design, build, and fly a crewed jet aircraft to maintain @VesselGroup/HoldSituation/minSpeed m/s in level flight, then return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.<br><b>After completion, the 'X-Planes (Mach 2 Supersonic)' contract will become available.</b></color> <br><color=white><br><b>After this contract has been completed, more 'X-Planes (Supersonic) Optional' contracts will become available.</b></color>
-	
-	genericDescription = Design, build and fly a crewed jet aircraft to maintain a specific speed in level flight, then return home safely.
+	description = <b>Program: X-Plane Research<br>Type: <color=blue>Optional</color></b><br><br>Design, build, and fly a crewed jet aircraft to maintain @VesselGroup/HoldSituation/minSpeed m/s in level flight, then return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.<br><br>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.<br><b>Current reward is at @rewardFactorPercent % of its nominal value. Elapsed/Expected Days: @elapsedDays / @RP0:expectedDays_XPlanesSupersonicOptional</b><br><br>This is a series of @maxCompletions contracts, of which @completions have been completed.
+	genericDescription = Design, build, and fly a crewed jet aircraft to maintain a specific speed in level flight, then return home safely.
 
 	synopsis = Fly a crewed jet aircraft to maintain @VesselGroup/HoldSituation/minSpeed m/s in level flight and hold, then return safely.
 
 	completedMessage = Congratulations on a successful flight!
 	
-	sortKey = 601
+	sortKey = 603
 
 	deadline = 0
 	cancellable = true
@@ -26,7 +25,7 @@ CONTRACT_TYPE
 
 	targetBody = HomeWorld()
 
-	maxCompletions = 1
+	maxCompletions = 3
 	maxSimultaneous = 1
 	prestige = Trivial
 
@@ -36,13 +35,28 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 15
+	rewardReputation = Round(18 * @rewardFactor, 1)
 	failureReputation = @rewardReputation
 	
 	DATA
 	{
 		type = int
-		index = $RP0_XPSS_Difficulty + 0
+		antiGrindCompletion = $XPSS_Completion == 0 ? (UniversalTime() - @RP0:expectedDays_XPlanesSupersonicOptional * 86400) : $XPSS_Completion
+	}
+	
+	DATA
+	{
+		type = int
+		index = $RP0_XPSS_Mid_Difficulty
+		completions = $RP0_XPSS_Mid_Difficulty
+	}
+
+	DATA
+	{
+		type = float
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @RP0:expectedDays_XPlanesSupersonicOptional * 20 - 9, 1), 2) / 3.46
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
 	}
 	
 	// ************* REQUIREMENTS ****************
@@ -58,7 +72,16 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = BreakSoundBarrier
+		contractType = XPlanesSupersonic
+	}
+	
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = XPlanesSupersonicMach2
+		invertRequirement  = true
 	}
 	
 	REQUIREMENT
@@ -68,18 +91,43 @@ CONTRACT_TYPE
 		tag = exclude_Supersonic
 		invertRequirement = true
 	}
-
+	
 	BEHAVIOUR
 	{
-		name = IncrementTheCount
+		name = IncrementTheCount 
 		type = Expression
 
+		CONTRACT_OFFERED
+		{
+			
+			XPSS_Completion = ($XPSS_Completion + 0) == 0 ? (UniversalTime() - @RP0:expectedDays_XPlanesSupersonicOptional * 86400) : ($XPSS_Completion + 0)
+		
+		}
+		
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			XPSS_Completion = UniversalTime()
-			RP0_XPSS_Difficulty = 4
 		}
 	}
+	
+	BEHAVIOUR
+	{
+		name = SetSSDifficulty
+		type = Expression
+
+
+		CONTRACT_COMPLETED_SUCCESS
+		{
+			RP0_XPSS_Mid_Difficulty = $RP0_XPSS_Mid_Difficulty + 1
+		}
+	}
+	
+	DATA
+	{
+		type = List<float>
+		minSpeedKMH = [ 500, 550, 600]
+	}
+	
 
 	PARAMETER
 	{
@@ -117,8 +165,8 @@ CONTRACT_TYPE
 		{
 			name = HoldSituation
 			type = ReachState
-			minSpeed = 450
-			maxSpeed = 475
+			minSpeed = @/minSpeedKMH.ElementAt(@/index)
+			maxSpeed = @/minSpeedKMH.ElementAt(@/index) + 25
 			minRateOfClimb = -10
 			maxRateOfClimb = 10
 			situation = FLYING
@@ -131,7 +179,7 @@ CONTRACT_TYPE
 			{
 				name = Duration
 				type = Duration
-				duration = 5m
+				duration = 3m
 				preWaitText = Reach specified speed.
 				waitingText = Testing highspeed flight
 				completionText = Flight completed, you are cleared to land.


### PR DESCRIPTION
Following changes:

Removing the generic SuperSonicOptional contract - splitting it into 3 contracts, that do the following:
2 optional flights before the 450m/s required
3 optionals between 450 and mach 2
12 optionals after mach 2.

retuning of reputation for all of that.
retuning of rep for rocketplay/altitude contracts.

Optional SS contracts only require 3 minutes of velocity maintenance.