### PR TITLE
Fix WarpToFundTarget with high incomes

### DIFF
--- a/Source/KerbalConstructionTime/BuildItems/FundTarget.cs
+++ b/Source/KerbalConstructionTime/BuildItems/FundTarget.cs
@@ -48,23 +48,27 @@ namespace KerbalConstructionTime
             
             double totalFunds = 0d; // outside the loop since we'll error-check this value.
             double time = -1; // outside the loop, this is what we'll return.
+            double bestTime = -1;
             for (int i = MaxIterations; i-- > 0 && timeUpper - timeLower > EpsilonTime;)
             {
                 time = (timeUpper + timeLower) * 0.5d;
                 // This is the post-CMQ delta.
                 double fundDelta = KCTGameStates.GetBudgetDelta(time);
                 totalFunds = baseFunds + fundDelta;
-                if (System.Math.Abs(targetFunds - totalFunds) < EpsilonFunds)
-                    return time;
 
-                if (totalFunds > targetFunds)
+                if (totalFunds >= targetFunds)
+                {
                     timeUpper = time;
+                    bestTime = time;
+                }
                 else
+                {
                     timeLower = time;
+                }
             }
 
-            if (System.Math.Abs(targetFunds - totalFunds) < EpsilonFunds)
-                return time;
+            if (bestTime > 0)
+                return bestTime;
 
             return -1d;
         }


### PR DESCRIPTION
The algorithm used to detect a fund target failed when daily income became relatively large, which caused it to error out towards the mid to late game.

With the new algorithm, it will warp to the soonest time that it determines the listed amount of money will be available, even if it's very slightly above the desired fund target.