### PR TITLE
Fix Lunar Mapper Contracts

### DIFF
--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiter.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiter.cfg
@@ -68,7 +68,6 @@ CONTRACT_TYPE
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			LunarOrbiter_Count = $LunarOrbiter_Count + 1
-			LunarOrbiter_Completion = UniversalTime()
 		}
 	}
 

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiter.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiter.cfg
@@ -30,7 +30,7 @@ CONTRACT_TYPE
 	rewardFunds = 0
 	failureFunds = 0
 	rewardReputation = 150
-	failureReputation = 0 // was @rewardReputation
+	failureReputation = @rewardReputation
 
 	// ************ REQUIREMENTS ************
 
@@ -105,14 +105,13 @@ CONTRACT_TYPE
 		PARAMETER
 		{
 			name = Visible Imager
-			type = PartValidation
-			part = RO-BasicTVCamera
-			part = RO-ImprovedTVCamera
-			part = RO-AdvancedImager
-			part = RO-HIRES
-			minCount = 1
-			title = Have at least 1 Visible Imaging Device of Level 2 or higher
-			hideChildren = true
+			type = RP1CollectScience
+			targetBody = Moon
+			experiment = RP0visibleImaging2
+			situation = InSpaceLow
+			fractionComplete = 1
+			minSubjectsToComplete = 1
+			title = Have at least 1 Visible Imaging Device of Level 2 or higher & collect science in at least 1 biome
 		}
 		
 		PARAMETER
@@ -136,17 +135,6 @@ CONTRACT_TYPE
 				waitingText = Checking for Stable Orbit
 				completionText = Stable Orbit: Confirmed
 			}
-		}
-		
-		PARAMETER
-		{
-			name = CollectScience
-			type = CollectScience
-			targetBody = Moon
-			recoveryMethod = RecoverOrTransmit
-			experiment = RP0visibleImaging2
-			title = Collect Science from around the Moon and transmit it to the KSC
-			hideChildren = true
 		}
 	}
 }

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiter.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiter.cfg
@@ -30,7 +30,7 @@ CONTRACT_TYPE
 	rewardFunds = 0
 	failureFunds = 0
 	rewardReputation = 150
-	failureReputation = @rewardReputation
+	failureReputation = 0 // was @rewardReputation
 
 	// ************ REQUIREMENTS ************
 
@@ -65,10 +65,6 @@ CONTRACT_TYPE
 		name = IncrementTheCount
 		type = Expression
 		
-		CONTRACT_OFFERED
-		{
-			LunarOrbiter_Completion = ($LunarOrbiter_Completion + 0) == 0 ? (UniversalTime() - 60 * 86400) : ($LunarOrbiter_Completion + 0)
-		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			LunarOrbiter_Count = $LunarOrbiter_Count + 1

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiterOptional.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiterOptional.cfg
@@ -76,7 +76,6 @@ CONTRACT_TYPE
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			LunarOrbiterOptional_Count = $LunarOrbiterOptional_Count + 1
-			LunarOrbiter_Completion = UniversalTime()
 		}
 	}
 

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiterOptional.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiterOptional.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = UncrewedLunarSurface
 
 
-	description = Design and successfully launch a probe into lunar orbit (with a maximum apiselene of @/maxApText.Print() km) and successfully transmit or return Visible Imaging 2 Science.<br><br>This is a series of @maxCompletions contracts, of which @index have been completed.
+	description = Design and successfully launch a probe into lunar orbit (with a maximum apiselene of @/maxApText.Print() km) and successfully transmit or return Visible Imaging 2 Science.<br><br>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.<br><b>Current reward is at @rewardFactorPercent % of its nominal value. Elapsed/Expected Days: @elapsedDays / @expectedDays</b><br><br>This is a series of @maxCompletions contracts, of which @index have been completed.
 	genericDescription =  Achieve lunar orbit and transmit pictures from at least a level two visible imaging device.
 
 	synopsis = Achieve lunar orbit and transmit imaging data
@@ -29,8 +29,8 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 150
-	failureReputation = 0 // was @rewardReputation
+	rewardReputation = Round(150 * @rewardFactor, 1)
+	failureReputation = @rewardReputation
 
 	// ************ REQUIREMENTS ************
 
@@ -73,10 +73,31 @@ CONTRACT_TYPE
 		name = IncrementTheCount
 		type = Expression
 		
+		CONTRACT_OFFERED
+		{
+			LunarOrbiter_Completion = ($LunarOrbiter_Completion + 0) == 0 ? (UniversalTime() - 60 * 86400) : ($LunarOrbiter_Completion + 0)
+		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			LunarOrbiterOptional_Count = $LunarOrbiterOptional_Count + 1
+			LunarOrbiter_Completion = UniversalTime()
 		}
+	}
+	
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $LunarOrbiter_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $LunarOrbiter_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 90
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 20 - 9, 1), 2) / 3.46
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
 	}
 
 	// ************ PARAMETERS ************
@@ -108,14 +129,13 @@ CONTRACT_TYPE
 		PARAMETER
 		{
 			name = Visible Imager
-			type = PartValidation
-			part = RO-BasicTVCamera
-			part = RO-ImprovedTVCamera
-			part = RO-AdvancedImager
-			part = RO-HIRES
-			minCount = 1
-			title = Have at least 1 Visible Imaging Device of Level 2 or higher
-			hideChildren = true
+			type = RP1CollectScience
+			targetBody = Moon
+			experiment = RP0visibleImaging2
+			situation = InSpaceLow
+			fractionComplete = 1
+			minSubjectsToComplete = 1
+			title = Have at least 1 Visible Imaging Device of Level 2 or higher & collect science in at least 1 biome
 		}
 		
 		PARAMETER
@@ -139,17 +159,6 @@ CONTRACT_TYPE
 				waitingText = Checking for Stable Orbit
 				completionText = Stable Orbit: Confirmed
 			}
-		}
-		
-		PARAMETER
-		{
-			name = CollectScience
-			type = CollectScience
-			targetBody = Moon
-			recoveryMethod = RecoverOrTransmit
-			experiment = RP0visibleImaging2
-			title = Collect Science from around the Moon and transmit it to the KSC
-			hideChildren = true
 		}
 	}
 }

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiterOptional.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiterOptional.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = UncrewedLunarSurface
 
 
-	description = Design and successfully launch a probe into lunar orbit (with a maximum apiselene of @/maxApText.Print() km) and successfully transmit or return Visible Imaging 2 Science.<br><br>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.<br><b>Current reward is at @rewardFactorPercent % of its nominal value. Elapsed/Expected Days: @elapsedDays / @expectedDays</b><br><br>This is a series of @maxCompletions contracts, of which @index have been completed.
+	description = Design and successfully launch a probe into lunar orbit (with a maximum apiselene of @/maxApText.Print() km) and successfully transmit or return Visible Imaging 2 Science.<br><br>This is a series of @maxCompletions contracts, of which @index have been completed.
 	genericDescription =  Achieve lunar orbit and transmit pictures from at least a level two visible imaging device.
 
 	synopsis = Achieve lunar orbit and transmit imaging data

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiterOptional.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiterOptional.cfg
@@ -29,8 +29,8 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = Round(150 * @rewardFactor, 1)
-	failureReputation = @rewardReputation
+	rewardReputation = 150
+	failureReputation = 0 // was @rewardReputation
 
 	// ************ REQUIREMENTS ************
 
@@ -72,32 +72,12 @@ CONTRACT_TYPE
 	{
 		name = IncrementTheCount
 		type = Expression
-		
-		CONTRACT_OFFERED
-		{
-			LunarOrbiter_Completion = ($LunarOrbiter_Completion + 0) == 0 ? (UniversalTime() - 60 * 86400) : ($LunarOrbiter_Completion + 0)
-		}
+
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			LunarOrbiterOptional_Count = $LunarOrbiterOptional_Count + 1
 			LunarOrbiter_Completion = UniversalTime()
 		}
-	}
-	
-	DATA
-	{
-		type = int
-		antiGrindCompletion = $LunarOrbiter_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $LunarOrbiter_Completion
-	}
-
-	DATA
-	{
-		type = float
-		expectedDays = 90
-
-		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
-		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 20 - 9, 1), 2) / 3.46
-		rewardFactorPercent = Round(@rewardFactor * 100, 1)
 	}
 
 	// ************ PARAMETERS ************


### PR DESCRIPTION
Fixes Lunar Orbiter & Mapper contracts requiring a physical level 2 imager. Uses RP1 parameter, requiring one biome be 100% complete.

Need comment on whether `hideChildren = true` is needed for the RP1CollectScience parameter. Currently removed since the parameter provides transparency on the progress of the biome sci collected.