### PR TITLE
Correct grammar

### DIFF
--- a/GameData/RP-1/Strategies/Leaders/LeadersContractors.cfg
+++ b/GameData/RP-1/Strategies/Leaders/LeadersContractors.cfg
@@ -42,7 +42,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = No Need to Innovate
 		multiplier = 0.95
-		effectDescription = flight tech
+		effectDescription = flight
 		nodeTypes
 		{
 			typeNode = Flight
@@ -183,7 +183,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = The N-1 Engines
 		multiplier = 1.1
-		effectDescription = staged rocket engines tech
+		effectDescription = staged rocket engine
 		nodeTypes
 		{
 			typeNode = Staged
@@ -194,7 +194,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = Staged Combustion Only
 		multiplier = 0.9
-		effectDescription = early and orbital rocket engines tech
+		effectDescription = early and orbital rocket engine
 		nodeTypes
 		{
 			typeNode = RocketEngines
@@ -244,7 +244,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = No Hydrolox
 		multiplier = 0.85
-		effectDescription = hydrolox engines tech
+		effectDescription = hydrolox engine
 		nodeTypes
 		{
 			typeNode = Hydrolox
@@ -334,7 +334,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = The NERVA Program
 		multiplier = 1.1
-		effectDescription = nuclear rocket engine tech
+		effectDescription = nuclear rocket engine
 		nodeTypes
 		{
 			typeNode = NTR
@@ -385,7 +385,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = The X-1
 		multiplier = 1.1
-		effectDescription = flight tech
+		effectDescription = flight
 		nodeTypes
 		{
 			typeNode = Flight
@@ -436,7 +436,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = Mercury and Gemini
 		multiplier = 1.1
-		effectDescription = command module tech
+		effectDescription = command module
 		nodeTypes
 		{
 			typeNode = Command
@@ -486,7 +486,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = Tank Design Experts
 		multiplier = 1.10
-		effectDescription = materials node tech
+		effectDescription = materials science
 		nodeTypes
 		{
 			typeNode = Materials
@@ -497,7 +497,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = Never Built Rocket Engines
 		multiplier = 0.9
-		effectDescription = early and orbital rocketry engine tech
+		effectDescription = early and orbital rocketry
 		nodeTypes
 		{
 			typeNode = RocketEngines
@@ -589,7 +589,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = Hydrolox is King
 		multiplier = 1.1
-		effectDescription = hydrolox engine tech
+		effectDescription = hydrolox engine
 		nodeTypes
 		{
 			typeNode = Hydrolox
@@ -600,7 +600,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = The RS-25 Came Too Late
 		multiplier = 0.90
-		effectDescription = staged combustion engine tech
+		effectDescription = staged combustion engine
 		nodeTypes
 		{
 			typeNode = Staged

--- a/GameData/RP-1/Strategies/Leaders/LeadersEngineers.cfg
+++ b/GameData/RP-1/Strategies/Leaders/LeadersEngineers.cfg
@@ -216,7 +216,7 @@ STRATEGY
 	{
 		name = IntegrationRateModifier
 		effectTitle = Creator of the Atlas
-		effectDescription = of balloon tanks
+		effectDescription = balloon tanks
 		multiplier = 1.1
 		appliesToParts = true
 		tags
@@ -240,7 +240,7 @@ STRATEGY
 	{
 		name = IntegrationRateModifier
 		effectTitle = Only Balloon-Focused
-		effectDescription = of service module tanks
+		effectDescription = service module tanks
 		multiplier = 0.9
 		appliesToParts = true
 		tags
@@ -317,7 +317,7 @@ STRATEGY
 	name = leaderMorgan
 	RP0conf = True
 	title = Mary Sherman Morgan
-	desc = Mary Sherman Morgan was a U.S. chemist and rocket fuel scientist who developed explosives during WWII, and then worked on hypergolic propellants during the Space Race. She invented the liquid fuel Hydyne in 1957, a 60/40 mix of unsymmetrical dimethylhydrazine and diethylenetriamine that offered a significant performance advantage over ethanol. Because it would be pared with liquid oxygen, she though Bagel would be a fun name, which would lead to engines being described as using Bagel-LOX. Unfortunately, the U.S. Army rejected this whimsical name. Hydyne powered the Jupiter-C rocket that launched the United States' first satellite, Explorer 1.
+	desc = Mary Sherman Morgan was a U.S. chemist and rocket fuel scientist who developed explosives during WWII, and then worked on hypergolic propellants during the Space Race. She invented the liquid fuel Hydyne in 1957, a 60/40 mix of unsymmetrical dimethylhydrazine and diethylenetriamine that offered a significant performance advantage over ethanol. Because it would be pared with liquid oxygen, she thought Bagel would be a fun name, which would lead to engines being described as using Bagel-LOX. Unfortunately, the U.S. Army rejected this whimsical name. Hydyne powered the Jupiter-C rocket that launched the United States' first satellite, Explorer 1.
 	department = Engineering
 	icon = RP-1/Strategies/Leaders/MaryShermanMorgan_ICON
 	iconDepartment = RP-1/Strategies/Leaders/MaryShermanMorgan

--- a/GameData/RP-1/Strategies/Leaders/LeadersScientists.cfg
+++ b/GameData/RP-1/Strategies/Leaders/LeadersScientists.cfg
@@ -248,7 +248,7 @@ STRATEGY
 	{
 		name = IntegrationRateModifier
 		effectTitle = Crew Safety
-		effectDescription = of cockpits
+		effectDescription = cockpits
 		multiplier = 0.9
 		appliesToParts = true
 		tags
@@ -361,7 +361,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = Leading Space Scientist
 		multiplier = 1.1
-		effectDescription = science tech
+		effectDescription = science (the very bottom row in R&D)
 		nodeTypes
 		{
 			typeNode = Science

--- a/GameData/RP-1/Strategies/Leaders/LeadersSubcontractors.cfg
+++ b/GameData/RP-1/Strategies/Leaders/LeadersSubcontractors.cfg
@@ -557,7 +557,7 @@ STRATEGY
 	{
 		name = IntegrationRateModifier
 		effectTitle = Thor and S-IVb tanks, NOTE: Currently non-functional
-		effectDescription = of isogrid tanks //Integral became isogrid, right?
+		effectDescription = of isogrid tanks
 		multiplier = 1.05
 		appliestovessel = true
 		tags

--- a/GameData/RP-1/Strategies/Leaders/LeadersSubcontractors.cfg
+++ b/GameData/RP-1/Strategies/Leaders/LeadersSubcontractors.cfg
@@ -94,7 +94,7 @@ STRATEGY
 	{
 		name = ResearchRateModifier
 		effectTitle = Crewed Spaceflight Visionary
-		effectDescription = command module tech
+		effectDescription = command module
 		multiplier = 1.05
 		transactionReasons
 		{
@@ -157,7 +157,7 @@ STRATEGY
 	{
 		name = ResearchRateModifier
 		effectTitle = Almaz and Salyut Stations
-		effectDescription = station tech
+		effectDescription = station
 		multiplier = 1.05
 		nodeTypes
 		{
@@ -222,7 +222,7 @@ STRATEGY
 									//TODO: leaving this like this now until I can target SC parts
 		effectTitle = Jet Engine Proficiency
 		multiplier = 1.1
-		effectDescription = flight tech
+		effectDescription = flight 
 		nodeTypes
 		{
 			typeNode = Flight
@@ -284,7 +284,7 @@ STRATEGY
 	{
 		name = ResearchRateModifier
 		effectTitle = The Proton Engines
-		effectDescription = staged rocket engines
+		effectDescription = staged rocket engine
 		multiplier = 1.05
 		appliesToParts = true
 		tags
@@ -557,7 +557,7 @@ STRATEGY
 	{
 		name = IntegrationRateModifier
 		effectTitle = Thor and S-IVb tanks, NOTE: Currently non-functional
-		effectDescription = of integral tanks
+		effectDescription = of isogrid tanks //Integral became isogrid, right?
 		multiplier = 1.05
 		appliestovessel = true
 		tags


### PR DESCRIPTION
Long-term, I think the autogenerated text for effects has some issues, but that should probably wait until after we've done some more leader shuffling.
I removed the word "tech", because if "research speed" gets put on the end automatically, it's unnecessary.
Thanks to the users who pointed these errors out