### PR TITLE
Allow Flexibility in OrbitalFlight2 Contract

### DIFF
--- a/GameData/RP-1/Contracts/Earth Crewed/OrbitalFlight2.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed/OrbitalFlight2.cfg
@@ -153,65 +153,70 @@ CONTRACT_TYPE
 			hideChildren = true
 			disableOnStateChange = true    // Probably to prevent the timers from getting reset when EVAing a naut
 		}
-
 		PARAMETER
-		{
-			name = Orbit1Wrapper
-			title = Complete orbit 1
-			type = All
-			disableOnStateChange = true
-			completeInSequence = true
-
-			PARAMETER
-			{
-				name = Orbit
-				type = Orbit
-				minPeA = @/startPeA
-				minApA = @/startApA
-				maxApA = @minApA + 100000
-				targetBody = HomeWorld()
-			}
-
-			PARAMETER
-			{
-				name = Duration
-				type = Duration
-				duration =  @/FirstDuration
-				preWaitText = Stay in specified orbit for
-				waitingText = Orbiting...
-				completionText = Orbits completed, you may alter your orbit now.
-			}
-		}
-
-		PARAMETER
-		{
-			name = Orbit2Wrapper
-			title = Complete orbit 2
-			type = All
-			disableOnStateChange = true
-			completeInSequence = true
-		
-			PARAMETER
-			{
-				name = Orbit2
-				type = Orbit
-				minPeA = @/startPeA
-				minApA = @/endApA
-				maxApA = @minApA + 200000
-				targetBody = HomeWorld()
-			}
+  		{
+    			name = OrbitWrapper
+       			title = Complete both orbits
+	  		type = All
+	  		notes = These orbits can be completed in any order.
+     			completeInSequence = true
 			
 			PARAMETER
 			{
-				name = Duration2
-				type = Duration
-				duration =  @/SecondDuration
-				preWaitText = Stay in specified orbit for
-				waitingText = Orbiting...
-				completionText = Orbits completed, you may fire retros when ready.
+				name = Orbit1Wrapper
+				title = Complete orbit 1
+				type = All
+				disableOnStateChange = true
+	
+				PARAMETER
+				{
+					name = Orbit
+					type = Orbit
+					minPeA = @/startPeA
+					minApA = @/startApA
+					maxApA = @minApA + 100000
+					targetBody = HomeWorld()
+				}
+	
+				PARAMETER
+				{
+					name = Duration
+					type = Duration
+					duration =  @/FirstDuration
+					preWaitText = Stay in specified orbit for
+					waitingText = Orbiting...
+					completionText = Orbits completed, you may alter your orbit now.
+				}
+			}
+	
+			PARAMETER
+			{
+				name = Orbit2Wrapper
+				title = Complete orbit 2
+				type = All
+				disableOnStateChange = true
+			
+				PARAMETER
+				{
+					name = Orbit2
+					type = Orbit
+					minPeA = @/startPeA
+					minApA = @/endApA
+					maxApA = @minApA + 200000
+					targetBody = HomeWorld()
+				}
+				
+				PARAMETER
+				{
+					name = Duration2
+					type = Duration
+					duration =  @/SecondDuration
+					preWaitText = Stay in specified orbit for
+					waitingText = Orbiting...
+					completionText = Orbits completed, you may fire retros when ready.
+				}
 			}
 		}
-
 		PARAMETER
 		{
 			name = ReturnHome


### PR DESCRIPTION
Allows the player to start in either orbit 1 or orbit 2, rather than just orbit 1, in the "Orbital Flight with Maneuvers and 2+ Crew" contract