### PR TITLE
Unstick HasCrewCapacity in contracts

### DIFF
--- a/GameData/RP-1/Contracts/Earth Crewed/OrbitalTestFlight.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed/OrbitalTestFlight.cfg
@@ -83,6 +83,7 @@ CONTRACT_TYPE
 			minCapacity = 1
 			title = Have space for at least 1 crewmember on board
 			hideChildren = true
+   			disableOnStateChange = false
 		}
 		
 		PARAMETER

--- a/GameData/RP-1/Contracts/Earth Crewed/OrbitalTestFlightAnimal.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed/OrbitalTestFlightAnimal.cfg
@@ -92,6 +92,7 @@ CONTRACT_TYPE
 			minCapacity = 1
 			title = Have space for at least 1 crewmember on board
 			hideChildren = true
+			disableOnStateChange = false
 		}
 		
 		PARAMETER

--- a/GameData/RP-1/Contracts/Earth Crewed/SuborbitalTestFlight.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed/SuborbitalTestFlight.cfg
@@ -140,6 +140,7 @@ CONTRACT_TYPE
 			minCapacity = 1
 			title = Have space for at least 1 crewmember on board
 			hideChildren = true
+			disableOnStateChange = false
 		}
 		PARAMETER
 		{

--- a/GameData/RP-1/Contracts/Space Stations/Add Crew Module Station.cfg
+++ b/GameData/RP-1/Contracts/Space Stations/Add Crew Module Station.cfg
@@ -83,6 +83,7 @@ CONTRACT_TYPE
 			minCapacity = 3
 			title = Launch a new module with space for at least 3 crew
 			hideChildren = true
+			disableOnStateChange = false
 		}
 		PARAMETER
 		{

--- a/GameData/RP-1/Contracts/Space Stations/First Space Station.cfg
+++ b/GameData/RP-1/Contracts/Space Stations/First Space Station.cfg
@@ -84,6 +84,7 @@ CONTRACT_TYPE
 			minCapacity = 3
 			title = Space for at least 3 crew
 			hideChildren = true
+			disableOnStateChange = false
 		}
 		PARAMETER
 		{

--- a/GameData/RP-1/Contracts/Space Stations/Improved Space Station.cfg
+++ b/GameData/RP-1/Contracts/Space Stations/Improved Space Station.cfg
@@ -98,6 +98,7 @@ CONTRACT_TYPE
 			minCapacity = 3
 			title = Space for at least 3 crew
 			hideChildren = true
+			disableOnStateChange = false
 		}
 		PARAMETER
 		{

--- a/GameData/RP-1/Contracts/Z Disabled Contracts/Lunar Space Station.cfg.DISABLED
+++ b/GameData/RP-1/Contracts/Z Disabled Contracts/Lunar Space Station.cfg.DISABLED
@@ -84,6 +84,7 @@ CONTRACT_TYPE
 			minCapacity = 4
 			title = Space for at least 4 crew
 			hideChildren = true
+			disableOnStateChange = false
 		}
 		PARAMETER
 		{

--- a/GameData/RP-1/Contracts/Z Disabled Contracts/Martian Space Station.cfg.DISABLED
+++ b/GameData/RP-1/Contracts/Z Disabled Contracts/Martian Space Station.cfg.DISABLED
@@ -84,6 +84,7 @@ CONTRACT_TYPE
 			minCapacity = 4
 			title = Space for at least 4 crew
 			hideChildren = true
+			disableOnStateChange = false
 		}
 		PARAMETER
 		{

--- a/GameData/RP-1/Contracts/Z Disabled Contracts/Surface Outposts (Disabled)/MarsOutpost.cfg.DISABLED
+++ b/GameData/RP-1/Contracts/Z Disabled Contracts/Surface Outposts (Disabled)/MarsOutpost.cfg.DISABLED
@@ -81,6 +81,7 @@ CONTRACT_TYPE
 			minCapacity = 4
 			title = Space for at least 4 crew
 			hideChildren = true
+			disableOnStateChange = false
 		}
 		PARAMETER
 		{

--- a/GameData/RP-1/Contracts/Z Disabled Contracts/Surface Outposts (Disabled)/MarsOutpostWithLab.cfg.DISABLED
+++ b/GameData/RP-1/Contracts/Z Disabled Contracts/Surface Outposts (Disabled)/MarsOutpostWithLab.cfg.DISABLED
@@ -75,6 +75,7 @@ CONTRACT_TYPE
 			minCapacity = 10
 			title = Space for at least 10 crew
 			hideChildren = true
+			disableOnStateChange = false
 		}
 		PARAMETER
 		{

--- a/GameData/RP-1/Contracts/Z Disabled Contracts/Surface Outposts (Disabled)/MoonOutpost.cfg.DISABLED
+++ b/GameData/RP-1/Contracts/Z Disabled Contracts/Surface Outposts (Disabled)/MoonOutpost.cfg.DISABLED
@@ -75,6 +75,7 @@ CONTRACT_TYPE
 			minCapacity = 4
 			title = Space for at least 4 crew
 			hideChildren = true
+			disableOnStateChange = false
 		}
 		PARAMETER
 		{

--- a/GameData/RP-1/Contracts/Z Disabled Contracts/Surface Outposts (Disabled)/MoonOutpostWithLab.cfg.DISABLED
+++ b/GameData/RP-1/Contracts/Z Disabled Contracts/Surface Outposts (Disabled)/MoonOutpostWithLab.cfg.DISABLED
@@ -68,6 +68,7 @@ CONTRACT_TYPE
 			minCapacity = 10
 			title = Space for at least 10 crew
 			hideChildren = true
+			disableOnStateChange = false
 		}
 		PARAMETER
 		{


### PR DESCRIPTION
Addresses #2106. Added `disableOnStateChange = false` to `HasCrewCapacity` parameters since it appears that once failed, they cannot return to being uncompleted. 