### PR TITLE
Reduce astro3 cost and crewed lunar payout

### DIFF
--- a/GameData/RP-1/CustomBarnKit.cfg
+++ b/GameData/RP-1/CustomBarnKit.cfg
@@ -47,7 +47,7 @@
 	}
 	@ASTRONAUTS
 	{
-		@upgrades = 25000, 500000, 1500000
+		@upgrades = 25000, 500000, 1000000
 		
 		@recruitHireBaseCost = 5000
 		@recruitHireFlatRate = 1.25

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -599,7 +599,7 @@ RP0_PROGRAM
 	requirementsPrettyText = Complete contracts X and Y
 	objectivesPrettyText = Send crew to flyby, orbit, and land on the Moon. 
 	nominalDurationYears = 9
-	baseFunding = 18000000
+	baseFunding = 17500000
 	fundingCurve = StrongBackloadedFundingCurve
 	repDeltaOnCompletePerYearEarly = 1445
 	repPenaltyPerYearLate = 1445

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -599,7 +599,7 @@ RP0_PROGRAM
 	requirementsPrettyText = Complete contracts X and Y
 	objectivesPrettyText = Send crew to flyby, orbit, and land on the Moon. 
 	nominalDurationYears = 9
-	baseFunding = 17500000
+	baseFunding = 16000000
 	fundingCurve = StrongBackloadedFundingCurve
 	repDeltaOnCompletePerYearEarly = 1445
 	repPenaltyPerYearLate = 1445


### PR DESCRIPTION
It'd actually still have a bit of an impact on balance in the form of maintenance costs, build time, and the fact that program payout depends on difficulty, while construction cost does not, but this could at least help a bit if too many construction costs is an issue.