### PR TITLE
Fix sounding and satellite payload rounding errors issue

### DIFF
--- a/GameData/RP-1/Contracts/Early Satellites (Heavy)/Downrange6000-Heavy.cfg
+++ b/GameData/RP-1/Contracts/Early Satellites (Heavy)/Downrange6000-Heavy.cfg
@@ -161,7 +161,7 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/missionPayload - 0.01
+			minQuantity = @/missionPayload - 0.1
 			title = Have a SoundingPayload of at least @/missionPayload.Print() units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Early Satellites (Heavy)/Downrange7500-Heavy.cfg
+++ b/GameData/RP-1/Contracts/Early Satellites (Heavy)/Downrange7500-Heavy.cfg
@@ -161,7 +161,7 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/missionPayload - 0.01
+			minQuantity = @/missionPayload - 0.1
 			title = Have a SoundingPayload of at least @/missionPayload.Print() units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Early Satellites (Light)/Downrange6000.cfg
+++ b/GameData/RP-1/Contracts/Early Satellites (Light)/Downrange6000.cfg
@@ -161,7 +161,7 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/missionPayload - 0.01
+			minQuantity = @/missionPayload - 0.1
 			title = Have a SoundingPayload of at least @/missionPayload.Print() units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Early Satellites (Light)/Downrange7500.cfg
+++ b/GameData/RP-1/Contracts/Early Satellites (Light)/Downrange7500.cfg
@@ -161,7 +161,7 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/missionPayload - 0.01
+			minQuantity = @/missionPayload - 0.1
 			title = Have a SoundingPayload of at least @/missionPayload.Print() units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Earth Satellites/ComTestSat.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/ComTestSat.cfg
@@ -162,7 +162,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = @/payload-0.01
+			minQuantity = @/payload-0.1
 			title = Have a ComSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Earth Satellites/EarlyComNetwork3.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/EarlyComNetwork3.cfg
@@ -166,7 +166,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 124.99
+			minQuantity = 124.9
 			title = Have a ComSatPayload of at least 125 units on the craft
 			disableOnStateChange = false
 		}

--- a/GameData/RP-1/Contracts/Earth Satellites/EarlyComNetwork4.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/EarlyComNetwork4.cfg
@@ -231,7 +231,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 124.99
+			minQuantity = 124.9
 			disableOnStateChange = false
 			title = Have a ComSatPayload of at least 125 units on the craft
 		}

--- a/GameData/RP-1/Contracts/Earth Satellites/EarlyComSat.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/EarlyComSat.cfg
@@ -164,7 +164,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = @/payload-0.01
+			minQuantity = @/payload-0.1
 			title = Have a ComSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Earth Satellites/FirstComSat.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/FirstComSat.cfg
@@ -128,7 +128,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = @/payload-0.01
+			minQuantity = @/payload-0.1
 			title = Have a ComSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Earth Satellites/FirstGEOSat.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/FirstGEOSat.cfg
@@ -81,7 +81,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = @/payload-0.01
+			minQuantity = @/payload-0.1
 			title = Have a ComSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Earth Satellites/FirstMolniyaSat.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/FirstMolniyaSat.cfg
@@ -109,7 +109,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = @/payload-0.01
+			minQuantity = @/payload-0.1
 			title = Have a ComSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Earth Satellites/FirstNavSat.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/FirstNavSat.cfg
@@ -89,7 +89,7 @@ CONTRACT_TYPE
 			name = HasNavSatPayload
 			type = HasResource
 			resource = NavSatPayload
-			minQuantity = 99.99
+			minQuantity = 99.9
 			title = Have a NavSatPayload of at least 100 units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Earth Satellites/FirstTundraSat.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/FirstTundraSat.cfg
@@ -110,7 +110,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = @/payload-0.01
+			minQuantity = @/payload-0.1
 			title = Have a ComSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Earth Satellites/FirstWeatherSat.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/FirstWeatherSat.cfg
@@ -95,7 +95,7 @@ CONTRACT_TYPE
 			name = HasWeatherSatPayload
 			type = HasResource
 			resource = WeatherSatPayload
-			minQuantity = @/payload-0.01
+			minQuantity = @/payload-0.1
 			title = Have a WeatherSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Earth Satellites/GEORepeatComSats.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/GEORepeatComSats.cfg
@@ -152,7 +152,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = @/payload-0.01
+			minQuantity = @/payload-0.1
 			title = Have a ComSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Earth Satellites/GeoComSatNetwork.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/GeoComSatNetwork.cfg
@@ -209,7 +209,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 314.99
+			minQuantity = 314.9
 			title = Have a ComSatPayload of at least 315 units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Sounding Rockets/DistanceSoundingDifficult.cfg
+++ b/GameData/RP-1/Contracts/Sounding Rockets/DistanceSoundingDifficult.cfg
@@ -202,7 +202,7 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/missionPayload - 0.01
+			minQuantity = @/missionPayload - 0.1
 			title = Have a SoundingPayload of at least @/missionPayload.Print() units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Sounding Rockets/DistanceSoundingIntermediate.cfg
+++ b/GameData/RP-1/Contracts/Sounding Rockets/DistanceSoundingIntermediate.cfg
@@ -192,7 +192,7 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/missionPayload - 0.01
+			minQuantity = @/missionPayload - 0.1
 			title = Have a SoundingPayload of at least @/missionPayload.Print() units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Sounding Rockets/Downrange.cfg
+++ b/GameData/RP-1/Contracts/Sounding Rockets/Downrange.cfg
@@ -163,7 +163,7 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/missionPayload - 0.01
+			minQuantity = @/missionPayload - 0.1
 			title = Have a SoundingPayload of at least @/missionPayload.Print() units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Sounding Rockets/SoundingDifficult.cfg
+++ b/GameData/RP-1/Contracts/Sounding Rockets/SoundingDifficult.cfg
@@ -211,7 +211,7 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/missionPayload -0.01
+			minQuantity = @/missionPayload -0.1
 			title = Have a SoundingPayload of at least @/missionPayload.Print() units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Sounding Rockets/SoundingIntermediate.cfg
+++ b/GameData/RP-1/Contracts/Sounding Rockets/SoundingIntermediate.cfg
@@ -184,7 +184,7 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/missionPayload - 0.01
+			minQuantity = @/missionPayload - 0.1
 			title = Have a SoundingPayload of at least @/missionPayload.Print() units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Sounding Rockets/SoundingRocketAdvancedBio.cfg
+++ b/GameData/RP-1/Contracts/Sounding Rockets/SoundingRocketAdvancedBio.cfg
@@ -141,7 +141,7 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/payload - 0.01
+			minQuantity = @/payload - 0.1
 			title = Have a SoundingPayload of at least @/payload units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Sounding Rockets/SoundingRocketAdvancedBioOptional.cfg
+++ b/GameData/RP-1/Contracts/Sounding Rockets/SoundingRocketAdvancedBioOptional.cfg
@@ -135,7 +135,7 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/payload - 0.01
+			minQuantity = @/payload - 0.1
 			title = Have a SoundingPayload of at least @/payload units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Sounding Rockets/SoundingRocketBio.cfg
+++ b/GameData/RP-1/Contracts/Sounding Rockets/SoundingRocketBio.cfg
@@ -141,7 +141,7 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/payload - 0.01
+			minQuantity = @/payload - 0.1
 			title = Have a SoundingPayload of at least @/payload units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-1/Contracts/Sounding Rockets/SoundingRocketBioOptional.cfg
+++ b/GameData/RP-1/Contracts/Sounding Rockets/SoundingRocketBioOptional.cfg
@@ -135,7 +135,7 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/payload - 0.01
+			minQuantity = @/payload - 0.1
 			title = Have a SoundingPayload of at least @/payload units on the craft
 			hideChildren = true
 		}


### PR DESCRIPTION
Trying to fix #2133:
"Sounding rocket contracts, 4500+ km downrange contracts and many satellite contracts ask for a fixed amount of sounding/comsat/navsat/weather sat payload. However, there is rounding in the game that can result in 499.99 shown as 500 and the contract not completing, even though the player was sure that the rocket has enough payload."

All the contract now have a margin of 0.01, which is apparently not enough. This PR changes 0.01 to 0.1.