### PR TITLE
Remove inclination mention from moonless bodies for orbital science probe contracts

### DIFF
--- a/GameData/RP-1/Contracts/Jupiter Observation/Jupiter Orbit_Rep.cfg
+++ b/GameData/RP-1/Contracts/Jupiter Observation/Jupiter Orbit_Rep.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = JupiterObservation
 	agent = Grand Tours
 
-	description = <b>Program: Jupiter Observation<br>Type: <color=blue>Optional</color></b><br><br>Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Jupiter.&br;The flexible parameters of this contract allow you to choose either a high inclination orbit for maximum surface coverage, or an orbit co-planar with the moons for repeated flybys.
+	description = <b>Program: Jupiter Observation<br>Type: <color=blue>Optional</color></b><br><br>Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Jupiter.&br;The flexible parameters of this contract allow you to choose either a high inclination orbit for maximum surface coverage, or an orbit coplanar with the moons for repeated flybys.
 
 	synopsis = Send an uncrewed probe into orbit around Jupiter
 

--- a/GameData/RP-1/Contracts/Mars/MarsOrbitRepeat.cfg
+++ b/GameData/RP-1/Contracts/Mars/MarsOrbitRepeat.cfg
@@ -4,7 +4,7 @@ CONTRACT_TYPE
 	title = Mars Orbital Science Probe
 	group = EarlyInnerPlanetProbes
 
-	description = <b>Program: Early Inner Planet Probes<br>Type: <color=blue>Optional</color></b><br><br>Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Mars.&br;The flexible parameters of this contract allow you to choose either a high inclination orbit for maximum surface coverage, or an orbit co-planar with the moons for repeated flybys.
+	description = <b>Program: Early Inner Planet Probes<br>Type: <color=blue>Optional</color></b><br><br>Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Mars.&br;The flexible parameters of this contract allow you to choose either a high inclination orbit for maximum surface coverage, or an orbit coplanar with the moons for repeated flybys.
 
 	synopsis = Send an uncrewed probe into orbit around Mars
 

--- a/GameData/RP-1/Contracts/Mercury Exploration/Mercury Orbit_Rep.cfg
+++ b/GameData/RP-1/Contracts/Mercury Exploration/Mercury Orbit_Rep.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = MercuryExploration
 	agent = Grand Tours
 
-	description = <b>Program: Mercury Exploration<br>Type: <color=blue>Optional</color></b><br><br>Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Mercury.&br;The flexible parameters of this contract allow you to choose a high inclination orbit for maximum surface coverage or any other inclination that matches your scientific objectives.
+	description = <b>Program: Mercury Exploration<br>Type: <color=blue>Optional</color></b><br><br>Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Mercury.
 
 	synopsis = Send an uncrewed probe into high inclination orbit around Mercury
 

--- a/GameData/RP-1/Contracts/Saturn Observation/Saturn Orbit_Rep.cfg
+++ b/GameData/RP-1/Contracts/Saturn Observation/Saturn Orbit_Rep.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = SaturnObservation
 	agent = Grand Tours
 
-	description = <b>Program: Saturn Observation<br>Type: <color=blue>Optional</color></b><br><br>Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Saturn.&br;The flexible parameters of this contract allow you to choose either a high inclination orbit for maximum surface coverage or an orbit co-planar with the moons for repeated flybys.
+	description = <b>Program: Saturn Observation<br>Type: <color=blue>Optional</color></b><br><br>Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Saturn.&br;The flexible parameters of this contract allow you to choose either a high inclination orbit for maximum surface coverage or an orbit coplanar with the moons for repeated flybys.
 
 	synopsis = Send an uncrewed probe into orbit around Saturn
 

--- a/GameData/RP-1/Contracts/Venus/VenusOrbitRepeat.cfg
+++ b/GameData/RP-1/Contracts/Venus/VenusOrbitRepeat.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = EarlyInnerPlanetProbes
 	agent = Grand Tours
 
-	description = <b>Program: Early Inner Planet Probes<br>Type: <color=blue>Optional</color></b><br><br>Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Venus.&br;The flexible parameters of this contract allow you to choose either a high inclination orbit for maximum surface coverage, or any other inclination that matches your scientific objectives.
+	description = <b>Program: Early Inner Planet Probes<br>Type: <color=blue>Optional</color></b><br><br>Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Venus.
 
 	synopsis = Send an uncrewed probe into orbit around Venus
 


### PR DESCRIPTION
The writing is awkward and I don't see why it needs to be included in that shortened form. Also, coplanar is one word and not hyphenated, see KSC-DF-107 Rev F 3.9.4 a.2