### PR TITLE
Rebalance later tanks

### DIFF
--- a/GameData/RP-1/ToolingDefinitions.cfg
+++ b/GameData/RP-1/ToolingDefinitions.cfg
@@ -180,7 +180,7 @@ TOOLING_DEFINITION
 	title = Steel Stir-Welded Tank
 	toolingName = Tool Tank
 	untooledMultiplier = 0.05
-	finalToolingCostMultiplier = 0.6
+	finalToolingCostMultiplier = 0.49
 	costMultiplierDL = 6
 	costReducers = Tank-Sep-Stir, Tank-Sep-Stir-HP, Tank-Sep-Starship-HP:0.25
 }
@@ -190,7 +190,7 @@ TOOLING_DEFINITION
 	title = HP Steel Stir-Welded Tank
 	toolingName = Tool Tank
 	untooledMultiplier = 0.05
-	finalToolingCostMultiplier = 0.6
+	finalToolingCostMultiplier = 0.49
 	costMultiplierDL = 6
 	costReducers = Tank-Sep-Stir, Tank-Sep-Stir-HP, Tank-Sep-Starship-HP:0.25
 }
@@ -322,8 +322,8 @@ TOOLING_DEFINITION
 	name = Tank-Balloon-SteelAlLi
 	title = Modern Balloon Tank
 	toolingName = Tool Tank
-	untooledMultiplier = 0.08
-	finalToolingCostMultiplier = 1.5
+	untooledMultiplier = 0.075
+	finalToolingCostMultiplier = 1.6
 	costMultiplierDL = 9
 	costReducers = Tank-Balloon-SteelAlCu
 }


### PR DESCRIPTION
Increase the max utilization of advanced composite tanks to match standard composite tanks
Make Starship tanks cheaper to balance their high weight
Change modern balloon tanks to only a bit more expensive than their refined counterparts (25% instead of 40%) and increase their tooling cost to 7% more than refined balloon tanks. 

Please merge at same time as RO PR