### PR TITLE
Remove cooldown on lunar sample return and add cooldown on X-plane (altitude)

### DIFF
--- a/GameData/RP-1/Contracts/Groups.cfg
+++ b/GameData/RP-1/Contracts/Groups.cfg
@@ -320,6 +320,7 @@ CONTRACT_GROUP
 		expectedDays_SoundingRocketBioOptional = 90
 		expectedDays_SoundingRocketFilmOptional = 125
 		expectedDays_RocketPlaneDevelopmentOptional = 120
+		expectedDays_XPlanesHighAltitudeOptional = 120
 		expectedDays_XPlanesSuborbital = 120
 		expectedDays_XPlanesSupersonicOptional = 120
 	}

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonLandingReturn.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonLandingReturn.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = UncrewedLunarSurface
 	agent = Federation Aeronautique Internationale
 
-	description = <b>Program: Uncrewed Lunar Surface Exploration<br>Type: <color=blue>Optional</color></b><br><br>You have successfully landed on the Moon, but our scientists need to know more information about the elements that make up the surface. Send a craft to land on the Moon and then return to Earth with scientific data from the Moon's surface.<br><br>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.<br><b>Current reward is at @rewardFactorPercent % of its nominal value. Elapsed/Expected Days: @elapsedDays / @RP0:expectedDays_MoonLandingReturn</b><br><br>This is a series of @maxCompletions contracts, of which @index have been completed.
+	description = <b>Program: Uncrewed Lunar Surface Exploration<br>Type: <color=blue>Optional</color></b><br><br>You have successfully landed on the Moon, but our scientists need to know more information about the elements that make up the surface. Send a craft to land on the Moon and then return to Earth with scientific data from the Moon's surface.<br><br>This is a series of @maxCompletions contracts, of which @index have been completed.
 	genericDescription = Launch a craft to achieve a soft landing on the Moon and return to Earth with the science.
 
 	synopsis = Launch a craft to achieve a soft landing on the Moon and return to Earth with the science
@@ -59,29 +59,10 @@ CONTRACT_TYPE
 		name = IncrementTheCount
 		type = Expression
 		
-		CONTRACT_OFFERED
-		{
-			MoonLandingReturn_Completion = ($MoonLandingReturn_Completion + 0) == 0 ? (UniversalTime() - @RP0:expectedDays_MoonLandingReturn * 86400) : ($MoonLandingReturn_Completion + 0)
-		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			MoonLandingReturnOptional_Count = $MoonLandingReturnOptional_Count + 1
-			MoonLandingReturn_Completion = UniversalTime()
 		}
-	}
-	
-	DATA
-	{
-		type = int
-		antiGrindCompletion = $MoonLandingReturn_Completion == 0 ? (UniversalTime() - @RP0:expectedDays_MoonLandingReturn * 86400) : $MoonLandingReturn_Completion
-	}
-
-	DATA
-	{
-		type = float
-		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
-		rewardFactor = Log(Max(@elapsedDays / @RP0:expectedDays_MoonLandingReturn * 20 - 9, 1), 2) / 3.46
-		rewardFactorPercent = Round(@rewardFactor * 100, 1)
 	}
 
 	// ************ PARAMETERS ************

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesHighAltitude.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesHighAltitude.cfg
@@ -82,10 +82,12 @@ CONTRACT_TYPE
 		CONTRACT_OFFERED
 		{
 			XPlanesHighAltitude_Count = $XPlanesHighAltitude_Count + 0
+			XPlanesHighAltitude_Completion = ($XPlanesHighAltitude_Completion + 0) == 0 ? (UniversalTime() - @RP0:expectedDays_XPlanesHighAltitudeOptional * 86400) : ($XPlanesHighAltitude_Completion + 0)
 		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			XPlanesHighAltitude_Count = $XPlanesHighAltitude_Count + 0 < 1 ? 1 : 5
+			XPlanesHighAltitude_Completion = UniversalTime()
 		}
 	}
 

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesHighAltitudeOptional.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesHighAltitudeOptional.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 
 	title = X-Planes (High Altitude) - Optional
 
-	description = <b>Program: X-Plane Research<br>Type: <color=blue>Optional</color></b><br><br>Design, build, and launch a crewed rocket or plane to put a person into the high atmosphere above @/altitudeKm km and return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.<br><br>This is a series of @maxCompletions contracts, of which @completions have been completed.
+	description = <b>Program: X-Plane Research<br>Type: <color=blue>Optional</color></b><br><br>Design, build, and launch a crewed rocket or plane to put a person into the high atmosphere above @/altitudeKm km and return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.<br><br>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.<br><b>Current reward is at @rewardFactorPercent % of its nominal value. Elapsed/Expected Days: @elapsedDays / @RP0:expectedDays_XPlanesHighAltitudeOptional</b><br><br>This is a series of @maxCompletions contracts, of which @completions have been completed.
 	genericDescription = Design, build and launch a crewed rocket or plane to put a person into high atmosphere above a specific altitude and return home safely.
 
 	synopsis = Launch a crewed vessel to @/altitudeKm km.
@@ -33,7 +33,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 15
+	rewardReputation = Round(15 * @rewardFactor, 1)
 	failureReputation = 0 // was @rewardReputation
 
 	DATA
@@ -113,11 +113,27 @@ CONTRACT_TYPE
 		CONTRACT_OFFERED
 		{
 			XPlanesHighAltitude_Count = $XPlanesHighAltitude_Count + 0
+			XPlanesHighAltitude_Completion = ($XPlanesHighAltitude_Completion + 0) == 0 ? (UniversalTime() - @RP0:expectedDays_XPlanesHighAltitudeOptional * 86400) : ($XPlanesHighAltitude_Completion + 0)
 		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			XPlanesHighAltitude_Count = $XPlanesHighAltitude_Count + 1
+			XPlanesHighAltitude_Completion = UniversalTime()
 		}
+	}
+	
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $XPlanesHighAltitude_Completion == 0 ? (UniversalTime() - @RP0:expectedDays_XPlanesHighAltitudeOptional * 86400) : $XPlanesHighAltitude_Completion
+	}
+
+	DATA
+	{
+		type = float
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @RP0:expectedDays_XPlanesHighAltitudeOptional * 3 - 0.05, 1), 2) / 1.5607
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
 	}
 
 	DATA


### PR DESCRIPTION
According to Maxsimal on Discord, contract series with more than three max completions should have a cooldown, which includes X-plane (altitude), with four max completions, but not lunar sample return, with three max completions. 