### PR TITLE
Fix Orbital Flight w/ 2 Crew missing orbital requirements in flight

### DIFF
--- a/GameData/RP-1/Contracts/Earth Crewed/OrbitalFlight2.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed/OrbitalFlight2.cfg
@@ -154,67 +154,58 @@ CONTRACT_TYPE
 			disableOnStateChange = true    // Probably to prevent the timers from getting reset when EVAing a naut
 		}
 		PARAMETER
-  		{
-    			name = OrbitWrapper
-       			title = Complete both orbits
-	  		type = All
-	  		notes = These orbits can be completed in any order.
-     			completeInSequence = true
-			
+		{
+			name = Orbit1Wrapper
+			title = Complete orbit 1
+			type = All
+			disableOnStateChange = true
+
 			PARAMETER
 			{
-				name = Orbit1Wrapper
-				title = Complete orbit 1
-				type = All
-				disableOnStateChange = true
-	
-				PARAMETER
-				{
-					name = Orbit
-					type = Orbit
-					minPeA = @/startPeA
-					minApA = @/startApA
-					maxApA = @minApA + 100000
-					targetBody = HomeWorld()
-				}
-	
-				PARAMETER
-				{
-					name = Duration
-					type = Duration
-					duration =  @/FirstDuration
-					preWaitText = Stay in specified orbit for
-					waitingText = Orbiting...
-					completionText = Orbits completed, you may alter your orbit now.
-				}
+				name = Orbit
+				type = Orbit
+				minPeA = @/startPeA
+				minApA = @/startApA
+				maxApA = @minApA + 100000
+				targetBody = HomeWorld()
 			}
-	
+
 			PARAMETER
 			{
-				name = Orbit2Wrapper
-				title = Complete orbit 2
-				type = All
-				disableOnStateChange = true
+				name = Duration
+				type = Duration
+				duration =  @/FirstDuration
+				preWaitText = Stay in specified orbit for
+				waitingText = Orbiting...
+				completionText = Orbits completed, you may alter your orbit now.
+			}
+		}
+
+		PARAMETER
+		{
+			name = Orbit2Wrapper
+			title = Complete orbit 2
+			type = All
+			disableOnStateChange = true
+		
+			PARAMETER
+			{
+				name = Orbit2
+				type = Orbit
+				minPeA = @/startPeA
+				minApA = @/endApA
+				maxApA = @minApA + 200000
+				targetBody = HomeWorld()
+			}
 			
-				PARAMETER
-				{
-					name = Orbit2
-					type = Orbit
-					minPeA = @/startPeA
-					minApA = @/endApA
-					maxApA = @minApA + 200000
-					targetBody = HomeWorld()
-				}
-				
-				PARAMETER
-				{
-					name = Duration2
-					type = Duration
-					duration =  @/SecondDuration
-					preWaitText = Stay in specified orbit for
-					waitingText = Orbiting...
-					completionText = Orbits completed, you may fire retros when ready.
-				}
+			PARAMETER
+			{
+				name = Duration2
+				type = Duration
+				duration =  @/SecondDuration
+				preWaitText = Stay in specified orbit for
+				waitingText = Orbiting...
+				completionText = Orbits completed, you may fire retros when ready.
 			}
 		}
 		PARAMETER


### PR DESCRIPTION
Reverts my previous PR done to the contract. `completeInSequence = true` is removed from the orbital parameters, which should still allow the contract to be done in any order instead of strictly orbit 1 -> orbit 2.