### PR TITLE
Fix the remaining sounding and satellite payload rounding errors

### DIFF
--- a/GameData/RP-1/Contracts/Earth Satellites/EarlyComNetwork3.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/EarlyComNetwork3.cfg
@@ -86,7 +86,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 124.99
+			minQuantity = 124.9
 			title = Have a ComSatPayload of at least 125 units on the craft
 			disableOnStateChange = false
 		}
@@ -126,7 +126,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 124.99
+			minQuantity = 124.9
 			title = Have a ComSatPayload of at least 125 units on the craft
 			disableOnStateChange = false
 		}

--- a/GameData/RP-1/Contracts/Earth Satellites/EarlyComNetwork4.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/EarlyComNetwork4.cfg
@@ -98,7 +98,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 124.99
+			minQuantity = 124.9
 			disableOnStateChange = false
 			title = Have a ComSatPayload of at least 125 units on the craft
 		}
@@ -145,7 +145,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 124.99
+			minQuantity = 124.9
 			disableOnStateChange = false
 			title = Have a ComSatPayload of at least 125 units on the craft
 		}
@@ -192,7 +192,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 124.99
+			minQuantity = 124.9
 			disableOnStateChange = false
 			title = Have a ComSatPayload of at least 125 units on the craft
 		}

--- a/GameData/RP-1/Contracts/Earth Satellites/GeoComSatNetwork.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/GeoComSatNetwork.cfg
@@ -79,7 +79,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 314.99
+			minQuantity = 314.9
 			title = Have a ComSatPayload of at least 315 units on the craft
 			hideChildren = true
 		}
@@ -125,7 +125,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 314.99
+			minQuantity = 314.9
 			title = Have a ComSatPayload of at least 315 units on the craft
 			hideChildren = true
 		}
@@ -171,7 +171,7 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 314.99
+			minQuantity = 314.9
 			title = Have a ComSatPayload of at least 315 units on the craft
 			hideChildren = true
 		}


### PR DESCRIPTION
#2134 fixed the issue for all single satellite missions, but not for satellite network missions, which needed changes in 3-4 lines and not in just one.  This PR changes all remaining 0.01 margins to 0.1.