### PR TITLE
Fix First Polar Orbit-Heavy contract group

### DIFF
--- a/GameData/RP-1/Contracts/Early Satellites (Heavy)/FirstPolarSat-Heavy.cfg
+++ b/GameData/RP-1/Contracts/Early Satellites (Heavy)/FirstPolarSat-Heavy.cfg
@@ -2,7 +2,7 @@ CONTRACT_TYPE
 {
 	name = FirstPolarSat-Heavy
 	title = First Polar Orbit Satellite (400 kg)
-	group = EarlySatellites
+	group = EarlySatellites-Heavy
 	agent = Federation Aeronautique Internationale
 
 	description = <b>Program: Early Satellites (Heavy)<br>Type: <color=green>Required</color></b><br><br>A polar orbit is one in which a satellite passes above or nearly above both poles of the body being orbited on each revolution. It therefore has an inclination of (or very close to) 90 degrees to the equator. A satellite in a polar orbit will pass over the equator at a different longitude on each of its orbits. Place a satellite weighing at least 400 kg into a polar orbit so we can study the advantages in greater detail.


### PR DESCRIPTION
This was in the correct program, but appeared in the Early Satellites-light contract group in Mission Control.