### PR TITLE
Including crewed cockpit experiments with their respective higher tier

### DIFF
--- a/GameData/RP-1/Science/Experiments/CrewScience/CockpitExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/CockpitExperiments.cfg
@@ -84,7 +84,7 @@ EXPERIMENT_DEFINITION
 		SampleMass = 0.002
  		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
 		BodyAllowed = HomeBody
-		IncludeExperiment = 
+		IncludeExperiment = RP0-SupersonicLow1
     }
 }
 
@@ -184,7 +184,7 @@ EXPERIMENT_DEFINITION
 		SampleMass = 0.002
 		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
 		BodyAllowed = HomeBody
- 		IncludeExperiment = 
+ 		IncludeExperiment = RP0-SupersonicHigh1
     }
 }
 


### PR DESCRIPTION
Basically, this includes "Supersonic flight" science into "Mach 2 flight" science, and it also includes "High Altitude flight" science into "Hypersonic flight" science (if you wanted to do hypersonic science for some stupid reason
This makes it similar to experiments like the visible imaging experiments, where higher tier experiments include lower tier experiments. These 2 sets of cockpit science fit together very well so it made sense to include the lower tiers in the higher tiers. The main change this will make is removing the need to have to do supersonic flight science if the player already has a mach 2 capable plane, which I actually encountered in my previous career.

I have tested both of these changes, and I can confirm that they work. There are some small quirks that I believe have to do with the fact that all cockpit science generates samples and not data. 
1. The name of the lower tier science will not appear on the "science recovered" screen to the left of the mission summary screen after the player recovers their vessel. It does count towards the total "science recovered" amount however.
2. The lower tier science will give exactly the same amount of science as the higher tier science did. This means that some flights (especially mach 2) have the ability to give out more lower tier science in one flight than is possible with a solely supersonic flight. (basically, it will go over the sample limit)

Images of testing:
https://cdn.discordapp.com/attachments/617156220146417664/1136477664832663572/image.png (Mach 2 flight done)
https://cdn.discordapp.com/attachments/617156220146417664/1136477875114102814/image.png (Mach 2 flight recovered)
https://cdn.discordapp.com/attachments/617156220146417664/1136477954101235854/image.png (Supersonic science gained)

https://cdn.discordapp.com/attachments/617156220146417664/1136486464268546058/image.png (Hypersonic flight done)
https://cdn.discordapp.com/attachments/617156220146417664/1136486711220764782/image.png (Hypersonic flight recovered)
https://cdn.discordapp.com/attachments/617156220146417664/1136486787632615544/image.png (High altitude science gained)