### PR TITLE
Revise TargetedSats and CommNetwork balancing

### DIFF
--- a/GameData/RP-1/Contracts/Earth Satellites/EarlyComNetwork3.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/EarlyComNetwork3.cfg
@@ -45,9 +45,17 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
+		contractType = FirstComSat
+	}
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
 		contractType = EarlyComNetwork4
 		invertRequirement = true
 	}
+
 	REQUIREMENT
 	{
 		name = AcceptContract

--- a/GameData/RP-1/Contracts/Earth Satellites/EarlyComNetwork4.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/EarlyComNetwork4.cfg
@@ -49,6 +49,13 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
+		contractType = FirstComSat
+	}
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
 		contractType = EarlyComNetwork3
 		invertRequirement = true
 	}

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -251,9 +251,9 @@ RP0_PROGRAM
 	requirementsPrettyText = Complete Targeted Satellites
 	objectivesPrettyText = Launch satellites to analyze weather and assist in navigation and reach a variety of specific orbits, including geostationary.
 	nominalDurationYears = 3
-	baseFunding = 360000
-	repDeltaOnCompletePerYearEarly = 110
-	repPenaltyPerYearLate = 110
+	baseFunding = 420000
+	repDeltaOnCompletePerYearEarly = 130
+	repPenaltyPerYearLate = 130
 	slots = 1
 
 	REQUIREMENTS
@@ -283,8 +283,8 @@ RP0_PROGRAM
 
 	CONFIDENCECOSTS
 	{
-		Normal = 250
-		Fast = 500
+		Normal = 300
+		Fast = 600
 	}
 }
 
@@ -296,9 +296,9 @@ RP0_PROGRAM
 	requirementsPrettyText = Complete Communication Network
 	objectivesPrettyText = Create a network of either 3 or 4 communications satellites.
 	nominalDurationYears = 2
-	baseFunding = 400000
-	repDeltaOnCompletePerYearEarly = 160
-	repPenaltyPerYearLate = 160
+	baseFunding = 280000
+	repDeltaOnCompletePerYearEarly = 110
+	repPenaltyPerYearLate = 110
 	slots = 1
 
 	REQUIREMENTS
@@ -312,6 +312,7 @@ RP0_PROGRAM
 
 	OBJECTIVES
 	{
+		complete_contract = FirstComSat
 		ANY
 		{
 			complete_contract = EarlyComNetwork3
@@ -327,8 +328,8 @@ RP0_PROGRAM
 
 	CONFIDENCECOSTS
 	{
-		Normal = 250
-		Fast = 500
+		Normal = 200
+		Fast = 400
 	}
 }
 


### PR DESCRIPTION
Give both programs the same per-year payout so there doesn't exist a perverse incentive to pick commnet over targeted sats.
Also, at least with the contracts we have right now in those programs I really can't justify commnet paying more than targetedSats. 