### PR TITLE
Make development/research contract groups adjacent

### DIFF
--- a/GameData/RP-1/Contracts/Groups.cfg
+++ b/GameData/RP-1/Contracts/Groups.cfg
@@ -25,16 +25,16 @@ CONTRACT_GROUP
 	}
 	CONTRACT_GROUP
 	{
-		name = EarlyXPlanes
-		displayName = X-Plane Research
+		name = SuborbRocketResearch
+		displayName = Suborbital Rocket Research
 		minVersion = 1.12.2
 		sortKey = 12
 		agent = Exploration
 	}
 	CONTRACT_GROUP
 	{
-		name = SuborbRocketResearch
-		displayName = Suborbital Rocket Research
+		name = EarlyXPlanes
+		displayName = X-Plane Research
 		minVersion = 1.12.2
 		sortKey = 13
 		agent = Exploration


### PR DESCRIPTION
The most common start in PLC seems to be taking the two SR programs, and I at least find it annoying that X-planes sits between them in MC. (Especially given that most research contracts depend on Karman Line in development.)