### PR TITLE
Fix MM issue by splitting ORed nodes

### DIFF
--- a/GameData/RP-1/ProcCosts.cfg
+++ b/GameData/RP-1/ProcCosts.cfg
@@ -193,11 +193,103 @@
 	{
 		%cost = 0.015
 	}
-	@TANK[NTO|CooledNTO|UDMH|Aerozine50|CooledAerozine50|MMH|IRFNA-III|IRFNA-IV|IWFNA|FLOX30|UH25|AK27|MON*|Hydyne|Hydrazine],*
+	@TANK[NTO],*
 	{
 		%cost = 0.01
 	}
-	@TANK[ClF3|ClF5|Diborane|Pentaborane|OF2|LqdFluorine|FLOX70|FLOX88|N2F4|CaveaB],*
+	@TANK[CooledNTO],*
+	{
+		%cost = 0.01
+	}
+	@TANK[UDMH],*
+	{
+		%cost = 0.01
+	}
+	@TANK[Aerozine50],*
+	{
+		%cost = 0.01
+	}
+	@TANK[CooledAerozine50],*
+	{
+		%cost = 0.01
+	}
+	@TANK[MMH],*
+	{
+		%cost = 0.01
+	}
+	@TANK[IRFNA-III],*
+	{
+		%cost = 0.01
+	}
+	@TANK[IRFNA-IV],*
+	{
+		%cost = 0.01
+	}
+	@TANK[IWFNA],*
+	{
+		%cost = 0.01
+	}
+	@TANK[FLOX30],*
+	{
+		%cost = 0.01
+	}
+	@TANK[UH25],*
+	{
+		%cost = 0.01
+	}
+	@TANK[AK27],*
+	{
+		%cost = 0.01
+	}
+	@TANK[MON*],*
+	{
+		%cost = 0.01
+	}
+	@TANK[Hydyne],*
+	{
+		%cost = 0.01
+	}
+	@TANK[Hydrazine],*
+	{
+		%cost = 0.01
+	}
+	@TANK[ClF3],*
+	{
+		%cost = 0.025
+	}
+	@TANK[ClF5],*
+	{
+		%cost = 0.025
+	}
+	@TANK[Diborane],*
+	{
+		%cost = 0.025
+	}
+	@TANK[Pentaborane],*
+	{
+		%cost = 0.025
+	}
+	@TANK[OF2],*
+	{
+		%cost = 0.025
+	}
+	@TANK[LqdFluorine],*
+	{
+		%cost = 0.025
+	}
+	@TANK[FLOX70],*
+	{
+		%cost = 0.025
+	}
+	@TANK[FLOX88],*
+	{
+		%cost = 0.025
+	}
+	@TANK[N2F4],*
+	{
+		%cost = 0.025
+	}
+	@TANK[CaveaB],*
 	{
 		%cost = 0.025
 	}


### PR DESCRIPTION
Fix two places where nodes that are not top-level were attempted to be filtered by using `|` to match multiple nodes (this doesn't work)

This might affect balance, so testing is needed!