### PR TITLE
Condense RP-1 description and continue 2159 discussion

### DIFF
--- a/RP-1.netkan
+++ b/RP-1.netkan
@@ -2,7 +2,7 @@
 	"spec_version" : "v1.26",
 	"identifier" : "RP-1",
 	"name"       : "Realistic Progression One (RP-1)",
-	"abstract"   : "Career for Realism Overhaul. Do not select/install this directly, instead select the RP-1 Express Install and let it install this automatically unless you know what you're doing and can fix it yourself.",
+	"abstract"   : "Career for Realism Overhaul. Select the RP-1 Express Install and do not touch this unless you know what you're doing.",
 	"license"    : "CC-BY-4.0",
 	"author"     : "RP-1 Group",
 	"$kref"      : "#/ckan/github/KSP-RO/RP-1",


### PR DESCRIPTION
Copy and paste from last message, would like to continue discussion on making the description shorter if willing: (need to make new pull request in order to submit commits again, sorry)

> "Leave this as it is" is not clear language--does it mean leave this checked? Unchecked? Something else? Need to explicitly say "unselect this", to make clear to the player that this mod is not to be directly installed unless they know what they're doing.

I think "leave this as it is" is quite clear, it pretty much just means don't touch it in as few words as possible. As lpg pointed out, saying "don't install this" could lead to people uninstalling it. (saying that the express will do it automatically may fix this, but its a lot of extra words, and it could be still interpreted as it would be fine to unselect this after the express install is selected)

How about "Select the RP-1 Express Install and do not touch this unless you know what you're doing."
I think "fix it yourself" is already included in "know what you're doing". Also, if I say to "not select it", then people could unselect after the express selects it, and if I say to "not unselect it" then people could select it along with the express install. "do not touch it" takes the best of both worlds by just telling people to leave it alone. I do not believe it can be made perfect, (as at least one person will think of it in an unpredicted way) but in my opinion this is a better solution.

>  I didn't think my edit was that big or controversial a change, and it seemed more straightforward than going round again a few times on wording, but I'm happy to continue that discussion!

I'm always happy to continue discussion! I want to make sure everyone is as happy as possible before we are done here. All I want to do is help.