### PR TITLE
Update Early Lunar Probes program description

### DIFF
--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -373,7 +373,7 @@ RP0_PROGRAM
 {
 	name = EarlyLunarProbes
 	title = Early Lunar Probes
-	description = The Moon is the first stepping stone to exploring the solar system. More than a light-second away, operating a probe at that distance is a worthy first step. This program requires new technology and heavier launch vehicles to take your space program's first steps toward studying the Moon up close. Complete it by putting a probe into orbit around the Moon.  This program will require Lunar Range Communications at a minimum, and will generally require upgrading Mission Control twice and the Tracking Station once in order to plan your journey. Basic Avionics and Probes unlocks deep-space avionics, which will be essential if you need guided avionics at the Moon.
+	description = The Moon is the first stepping stone to exploring the solar system. More than a light-second away, operating a probe at that distance is a worthy first step. This program requires new technology and heavier launch vehicles to take your space program's first steps toward studying the Moon up close. Complete it by putting a probe into orbit around the Moon.  This program will require Lunar Range Communications at a minimum, and will generally require upgrading Mission Control and the Tracking Station in order to plan your journey. Basic Avionics and Probes unlocks deep-space avionics, which will be essential if you need guided avionics at the Moon.
 	requirementsPrettyText = Achieve orbit of the Earth
 	objectivesPrettyText = Complete the lunar flyby, lunar impact, and lunar orbit contracts.
 	nominalDurationYears = 4


### PR DESCRIPTION
Flight planning is unlocked with the first mission control upgrade, so the program description needs updating.