### PR TITLE
Increase avionics to 1.6t for Mercury capsule

### DIFF
--- a/GameData/RP-1/Avionics.cfg
+++ b/GameData/RP-1/Avionics.cfg
@@ -72,7 +72,7 @@
 {
 	%MODULE[ModuleAvionics]
 	{
-		%massLimit = 1.5
+		%massLimit = 1.6
 		%interplanetary = False
 	}
 	%SetupKOS = Mercury


### PR DESCRIPTION
This would improve support for custom service module or deorbit stages, including ones with HTP.