### PR TITLE
Rework program progress, duration, funding to be incremental

### DIFF
--- a/Source/Harmony/StrategySystem.cs
+++ b/Source/Harmony/StrategySystem.cs
@@ -184,7 +184,7 @@ namespace RP0.Harmony
                     UnityEngine.Debug.LogWarning($"[RP-0]: Warning: Program {p.name} does not have its strategy activated. Doing so now.");
                     if (s is ProgramStrategy ps)
                     {
-                        ps.PerformActivate(false, false);
+                        ps.PerformActivate(false);
                         ps.dateActivated = p.acceptedUT; // overwrite with correct activation UT
                     }
                 }

--- a/Source/Harmony/StrategySystem.cs
+++ b/Source/Harmony/StrategySystem.cs
@@ -187,9 +187,10 @@ namespace RP0.Harmony
                         ps.PerformActivate(false, false);
                         ps.dateActivated = p.acceptedUT; // overwrite with correct activation UT
                     }
-                    
                 }
             }
+
+            ProgramHandler.Instance.OnLoadStrategiesComplete();
 
             KerbalConstructionTime.KCTGameStates.RecalculateBuildRates();
         }

--- a/Source/Leaders/StrategyRP0.cs
+++ b/Source/Leaders/StrategyRP0.cs
@@ -117,7 +117,7 @@ namespace RP0
             if (!CanBeActivated(out _))
                 return false;
 
-            PerformActivate(true, true);
+            PerformActivate(true);
 
             
 
@@ -127,7 +127,7 @@ namespace RP0
         /// <summary>
         /// Teh
         /// </summary>
-        public void PerformActivate(bool useCurrency, bool recalcRates)
+        public void PerformActivate(bool useCurrency)
         {
             isActive = true;
             Register();
@@ -145,15 +145,14 @@ namespace RP0
             if (useCurrency)
                 CurrencyUtils.ProcessCurrency(TransactionReasonsRP0.StrategySetup, ConfigRP0.SetupCosts, true);
 
-            if (recalcRates)
+            if (!(this is Programs.ProgramStrategy))
             {
                 KerbalConstructionTime.KCTGameStates.RecalculateBuildRates();
                 MaintenanceHandler.Instance?.UpdateUpkeep();
-            }
-
-            if(!(this is Programs.ProgramStrategy))
+                Programs.ProgramHandler.Instance.OnLeaderChange();
                 // FIXME add setup cost if we add setup costs to leaders
                 CareerLog.Instance?.AddLeaderEvent(Config.Name, true, 0d);
+            }
         }
 
         /// <summary>
@@ -183,10 +182,13 @@ namespace RP0
 
             Unregister();
 
-            KerbalConstructionTime.KCTGameStates.RecalculateBuildRates();
-            
             if (!(this is Programs.ProgramStrategy))
+            {
+                KerbalConstructionTime.KCTGameStates.RecalculateBuildRates();
+                MaintenanceHandler.Instance?.UpdateUpkeep();
+                Programs.ProgramHandler.Instance.OnLeaderChange();
                 CareerLog.Instance?.AddLeaderEvent(Config.Name, false, deactivateRep);
+            }
 
             return true;
         }

--- a/Source/Leaders/StrategyRP0.cs
+++ b/Source/Leaders/StrategyRP0.cs
@@ -148,7 +148,6 @@ namespace RP0
             if (recalcRates)
             {
                 KerbalConstructionTime.KCTGameStates.RecalculateBuildRates();
-                Programs.ProgramHandler.Instance.ClampFunding();
                 MaintenanceHandler.Instance?.UpdateUpkeep();
             }
 
@@ -185,7 +184,6 @@ namespace RP0
             Unregister();
 
             KerbalConstructionTime.KCTGameStates.RecalculateBuildRates();
-            Programs.ProgramHandler.Instance.ClampFunding();
             
             if (!(this is Programs.ProgramStrategy))
                 CareerLog.Instance?.AddLeaderEvent(Config.Name, false, deactivateRep);

--- a/Source/Maintenance/MaintenanceGUI.cs
+++ b/Source/Maintenance/MaintenanceGUI.cs
@@ -545,7 +545,7 @@ namespace RP0
                 GUILayout.BeginHorizontal();
                 GUILayout.Label(" Nominal Deadline:", HighLogic.Skin.label, GUILayout.Width(160));
                 const double secsPerYear = 365.25d * 86400d;
-                GUILayout.Label(KSPUtil.PrintDate(p.acceptedUT + p.DurationYears * secsPerYear, false), RightLabel, GUILayout.Width(160));
+                GUILayout.Label(KSPUtil.PrintDate(p.RemainingDurationYears * secsPerYear, false), RightLabel, GUILayout.Width(160));
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();

--- a/Source/Programs/Program.cs
+++ b/Source/Programs/Program.cs
@@ -314,6 +314,11 @@ namespace RP0.Programs
             return Math.Max(0, funds2 - fundsPaidOut);
         }
 
+        public void OnLeaderChange()
+        {
+            deadlineUT = Planetarium.GetUniversalTime() + (1d - FracElapsed) * DurationYears * secsPerYear;
+        }
+
         public void ProcessFunding()
         {
             if (TotalFunding < 1)

--- a/Source/Programs/Program.cs
+++ b/Source/Programs/Program.cs
@@ -547,7 +547,7 @@ namespace RP0.Programs
                         double fundAtYear = GetFundsAtTime(Math.Min(i, duration) * secPerYear);
                         double paidThisYear = fundAtYear - totalPaid;
                         totalPaid = fundAtYear;
-                        text += $"\nYear {(lastYear > 10 ? " " : string.Empty)}{i}:  {CurrencyModifierQueryRP0.RunQuery(TransactionReasonsRP0.ProgramFunding, paidThisYear, 0d, 0d).GetCostLineOverride(false, false, false, true)}";
+                        text += $"\nNominal Year {(lastYear > 10 ? " " : string.Empty)}{i}:  {CurrencyModifierQueryRP0.RunQuery(TransactionReasonsRP0.ProgramFunding, paidThisYear, 0d, 0d).GetCostLineOverride(false, false, false, true)}";
                     }
                 }
             }

--- a/Source/Programs/Program.cs
+++ b/Source/Programs/Program.cs
@@ -43,8 +43,14 @@ namespace RP0.Programs
         [Persistent]
         public double nominalDurationYears;
         public double DurationYears => DurationYearsCalc(speed, nominalDurationYears);
+        public double EffectiveDurationYears => acceptedUT == 0d ? DurationYears : ElapsedYears + RemainingDurationYears;
+        public double ElapsedYears => acceptedUT == 0d ? 0d : (Planetarium.GetUniversalTime() - acceptedUT) / secsPerYear;
 
-        public double ElapsedYears => (Planetarium.GetUniversalTime() - acceptedUT) / secsPerYear;
+        public double RemainingDurationYears => (1d - fracElapsed) * DurationYears;
+
+        [Persistent]
+        public double fracElapsed = -1d;
+        public double FracElapsed => fracElapsed;
 
         public static double DurationYearsCalc(Speed spd, double years)
         {
@@ -70,6 +76,9 @@ namespace RP0.Programs
 
         [Persistent]
         public double acceptedUT;
+
+        [Persistent]
+        public double deadlineUT;
 
         [Persistent]
         public double objectivesCompletedUT;
@@ -289,7 +298,9 @@ namespace RP0.Programs
                 lastPaymentUT = Planetarium.GetUniversalTime(),
                 totalFunding = TotalFunding,
                 fundsPaidOut = 0,
-                repPenaltyAssessed = 0
+                repPenaltyAssessed = 0,
+                fracElapsed = 0,
+                deadlineUT = acceptedUT + DurationYears * secsPerYear
             };
             CareerLog.Instance?.ProgramAccepted(p);
 
@@ -298,37 +309,36 @@ namespace RP0.Programs
 
         public double GetFundsForFutureTimestamp(double ut)
         {
-            double time2 = ut - acceptedUT;
-            double funds2 = GetFundsAtTime(time2);
+            double frac2 = fracElapsed + (ut - Planetarium.GetUniversalTime()) / (secsPerYear * DurationYears);
+            double funds2 = GetFundsAtFrac(frac2);
             return Math.Max(0, funds2 - fundsPaidOut);
-        }
-
-        /// <summary>
-        /// This clamps current program fund tracking to expected. It is used when leaders change
-        /// (which may change program durations)
-        /// </summary>
-        public void ClampFunding()
-        {
-            double calculatedLastTotalFunds = GetFundsAtTime(lastPaymentUT - acceptedUT);
-            if (fundsPaidOut > calculatedLastTotalFunds + 100d || fundsPaidOut < calculatedLastTotalFunds - 100d) // with slop
-                fundsPaidOut = calculatedLastTotalFunds;
         }
 
         public void ProcessFunding()
         {
-            if (TotalFunding < 1) return;
+            if (TotalFunding < 1)
+                return;
 
+            double duration = DurationYears;
             double nowUT = Planetarium.GetUniversalTime();
-            double time2 = nowUT - acceptedUT;
-            double funds2 = GetFundsAtTime(time2);
-            double fundsToAdd = Math.Max(0d, funds2 - fundsPaidOut);
-            lastPaymentUT = nowUT;
+            double frac2 = fracElapsed + (nowUT - lastPaymentUT) / (secsPerYear * duration);
+            if (fracElapsed == frac2)
+                return;
 
-            RP0Debug.Log($"[RP-0] Adding {fundsToAdd} funds for program {name} - amount at time {nowUT / DurationYears / (86400d * 365.25d)} should be {funds2} but is {fundsPaidOut}");
-            fundsPaidOut += fundsToAdd;
-            Funding.Instance.AddFunds(fundsToAdd, TransactionReasons.Mission);
+            // update deadline
+            if (frac2 < 1d)
+            {
+                // we're still in the future, recompute based on remaining duration
+                deadlineUT = nowUT + (1d - frac2) * duration * secsPerYear;
+            }
+            else if (fracElapsed < 1d)
+            {
+                // compute when deadline should have been
+                deadlineUT = lastPaymentUT + (1d - fracElapsed) * duration * secsPerYear;
+            }
 
-            double repLost = GetRepLossAtTime(time2);
+            // First, handle rep loss
+            double repLost = GetRepLossAtFrac(frac2);
             if (repLost > 0d)
             {
                 if (repPenaltyAssessed <= 0)
@@ -337,16 +347,31 @@ namespace RP0.Programs
                     {
                         KSP.UI.Screens.MessageSystem.Instance.AddMessage(new KSP.UI.Screens.MessageSystem.Message("Program Duration Expired",
                             $"The duration of the {title} program has expired.\n\n"
-                            + ( CanComplete ? "It should be completed in the Administration Building before we lose any more reputation."
+                            + (CanComplete ? "It should be completed in the Administration Building before we lose any more reputation."
                                 : "We need to finish its objectives as soon as possible!"),
                             KSP.UI.Screens.MessageSystemButton.MessageButtonColor.ORANGE, KSP.UI.Screens.MessageSystemButton.ButtonIcons.DEADLINE));
                     }
                 }
                 double repLossToApply = repLost - repPenaltyAssessed;
-                repPenaltyAssessed += repLossToApply;
-                Reputation.Instance.AddReputation((float)-repLossToApply, TransactionReasons.Mission);
-                RP0Debug.Log($"[RP-0] Penalizing rep by {repLossToApply} for program {name}");
+                if (repLossToApply > 0d)
+                {
+                    repPenaltyAssessed += repLossToApply;
+                    Reputation.Instance.AddReputation((float)-repLossToApply, TransactionReasons.Mission);
+                    RP0Debug.Log($"[RP-0] Penalizing rep by {repLossToApply} for program {name}");
+                }
             }
+
+            double funds2 = GetFundsAtFrac(frac2);
+            double fundsToAdd = funds2 - fundsPaidOut;
+            if (fundsToAdd <= 0d)
+                return;
+
+            lastPaymentUT = nowUT;
+            fracElapsed = frac2;
+
+            RP0Debug.Log($"[RP-0] Adding {fundsToAdd} funds for program {name} - amount at time {nowUT / DurationYears / (86400d * 365.25d)} should be {funds2} but is {fundsPaidOut}");
+            fundsPaidOut += fundsToAdd;
+            Funding.Instance.AddFunds(fundsToAdd, TransactionReasons.Mission);
         }
 
         public void MarkObjectivesComplete()
@@ -363,12 +388,13 @@ namespace RP0.Programs
 
         public double RepForComplete(double ut)
         {
-            double timeDelta = DurationYears * secsPerYear - (ut - acceptedUT);
-            double repDelta = 0d;
-            if (timeDelta > 0)
-            {
-                repDelta = (timeDelta / secsPerYear * repDeltaOnCompletePerYearEarly);
-            }
+            double duration = DurationYears;
+            double newFracElapsed = fracElapsed + (ut - lastPaymentUT) / (duration * secsPerYear);
+            if (newFracElapsed >= 1d)
+                return 0d;
+
+            double yearDelta = (1d - newFracElapsed) * duration;
+            double repDelta = yearDelta * repDeltaOnCompletePerYearEarly;
             return repDelta;
         }
 
@@ -388,21 +414,22 @@ namespace RP0.Programs
 
         public double GetFundsAtTime(double time)
         {
-            double fractionOfTotalDuration = time / DurationYears / secsPerYear;
+            return GetFundsAtFrac(time / DurationYears / secsPerYear);
+        }
+
+        public double GetFundsAtFrac(double fractionOfTotalDuration)
+        {
             DoubleCurve curve = ProgramHandler.Settings.FundingCurve(fundingCurve);
             double curveFactor = curve.Evaluate(fractionOfTotalDuration);
             return curveFactor * TotalFunding;
         }
 
-        private double GetRepLossAtTime(double time)
+        private double GetRepLossAtFrac(double frac)
         {
-            const double recip = 1d / secsPerYear;
-            double extraTime = time - DurationYears * secsPerYear;
-            if (extraTime > 0d)
-            {
-                return RepPenaltyPerYearLate * (extraTime * recip);
-            }
-            return 0d;
+            if (frac <= 1d)
+                return 0d;
+
+            return RepPenaltyPerYearLate * (1d - frac) * DurationYears;
         }
 
         public string GetDescription(bool extendedInfo)
@@ -444,9 +471,9 @@ namespace RP0.Programs
                 else
                 {
                     if (extendedInfo)
-                        text += $"Deadline: {KSPUtil.dateTimeFormatter.PrintDate(acceptedUT + duration * 365.25d * 86400d, false, false)}";
+                        text += $"Deadline: {KSPUtil.dateTimeFormatter.PrintDate(deadlineUT, false, false)}";
                     else
-                        text += $"Deadline: {KSPUtil.dateTimeFormatter.PrintDateCompact(acceptedUT + duration * 365.25d * 86400d, false, false)}";
+                        text += $"Deadline: {KSPUtil.dateTimeFormatter.PrintDateCompact(deadlineUT, false, false)}";
                 }
             }
             else
@@ -498,9 +525,8 @@ namespace RP0.Programs
                     int lastYear = (int)Math.Ceiling(duration) + 1;
                     if (IsActive)
                     {
-                        double relativeUT = Planetarium.GetUniversalTime() - acceptedUT;
-                        startYear = (int)(relativeUT / (86400d * 365.25d)) + 1;
-                        totalPaid = GetFundsAtTime(relativeUT);
+                        startYear = (int)(fracElapsed * duration) + 1;
+                        totalPaid = fundsPaidOut;
                     }
                     else
                     {

--- a/Source/Programs/Program.cs
+++ b/Source/Programs/Program.cs
@@ -319,6 +319,9 @@ namespace RP0.Programs
             if (TotalFunding < 1)
                 return;
 
+            if (!ProgramHandler.Instance.Ready)
+                return;
+
             double duration = DurationYears;
             double nowUT = Planetarium.GetUniversalTime();
             double frac2 = fracElapsed + (nowUT - lastPaymentUT) / (secsPerYear * duration);

--- a/Source/Programs/ProgramFundingOverview.cs
+++ b/Source/Programs/ProgramFundingOverview.cs
@@ -129,7 +129,7 @@ namespace RP0.Programs
             };
             data.AddData(yValues, XKCDColors.BrightCyan, "√", false);
 
-            UpdateGraph(data, 0, shownYears, _program.ElapsedYears, _program.DurationYears);
+            UpdateGraph(data, 0, shownYears, _program.FracElapsed * _program.DurationYears, _program.DurationYears);
 
             var fi = typeof(ferramGraph).GetField("graph", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             var obj = fi.GetValue(_graph);

--- a/Source/Programs/ProgramHandler.cs
+++ b/Source/Programs/ProgramHandler.cs
@@ -199,15 +199,6 @@ namespace RP0.Programs
             node.AddNode(disableds);
         }
 
-        public void ClampFunding()
-        {
-            foreach (Program p in ActivePrograms)
-            {
-                p.ClampFunding();
-            }
-            RP0Debug.Log($"[RP-0] ProgramHandler clamped active program funding on leader change.");
-        }
-
         public void ProcessFunding()
         {
             Profiler.BeginSample("RP0ProcessFunding");

--- a/Source/Programs/ProgramHandler.cs
+++ b/Source/Programs/ProgramHandler.cs
@@ -17,7 +17,7 @@ namespace RP0.Programs
     [KSPScenario((ScenarioCreationOptions)480, new GameScenes[] { GameScenes.EDITOR, GameScenes.FLIGHT, GameScenes.SPACECENTER, GameScenes.TRACKSTATION })]
     public class ProgramHandler : ScenarioModule
     {
-        private static int VERSION = 1;
+        private static int VERSION = 2;
         [KSPField(isPersistant = true)]
         public int LoadedSaveVersion = 0;
 
@@ -168,6 +168,16 @@ namespace RP0.Programs
 
                             break;
                         }
+                    }
+                }
+            }
+            if (LoadedSaveVersion < 2)
+            {
+                foreach (var p in ActivePrograms)
+                {
+                    if (p.fracElapsed < 0d)
+                    {
+                        p.fracElapsed = (p.lastPaymentUT - p.acceptedUT) / (p.DurationYears * (365.25d * 86400d));
                     }
                 }
             }

--- a/Source/Programs/ProgramHandler.cs
+++ b/Source/Programs/ProgramHandler.cs
@@ -230,6 +230,15 @@ namespace RP0.Programs
             node.AddNode(disableds);
         }
 
+        public void OnLeaderChange()
+        {
+            foreach (Program p in ActivePrograms)
+            {
+                p.OnLeaderChange();
+            }
+            RP0Debug.Log($"[RP-0] ProgramHandler clamped active program funding on leader change.");
+        }
+
         public void ProcessFunding()
         {
             Profiler.BeginSample("RP0ProcessFunding");


### PR DESCRIPTION
This PR fixes issues with Milt Rosen (and any other future leaders that might change program duration) by changing the program backend so that instead of computing everything based off (time - acceptedTime) it tracks the fraction elapsed. This means that if you take Rosen halfway through, your 20% faster will only affect the remaining 50% of program duration, and if you then fire him only the remaining duration will get extended back out. Taking or firing him after program deadline expiration still behaves a little strangely but this fixes the majority of the issues. Will close #2207