### PR TITLE
Make RP-1 description more clear with new system

### DIFF
--- a/RP-1.netkan
+++ b/RP-1.netkan
@@ -2,7 +2,7 @@
 	"spec_version" : "v1.26",
 	"identifier" : "RP-1",
 	"name"       : "Realistic Progression One (RP-1)",
-	"abstract"   : "Career for Realism Overhaul. Select/install the RP-1 Express Install first, and then select this when it asks you to pick between the current version or the legacy version.",
+	"abstract"   : "Career for Realism Overhaul. Select/install the RP-1 Express Install first, follow its instructions, and then select this when it asks you to pick between the current version or the legacy version.",
 	"license"    : "CC-BY-4.0",
 	"author"     : "RP-1 Group",
 	"$kref"      : "#/ckan/github/KSP-RO/RP-1",

--- a/RP-1.netkan
+++ b/RP-1.netkan
@@ -2,7 +2,7 @@
 	"spec_version" : "v1.26",
 	"identifier" : "RP-1",
 	"name"       : "Realistic Progression One (RP-1)",
-	"abstract"   : "Career for Realism Overhaul. Do not select/install this directly, instead select the RP-1 Express Install and let it install this automatically unless you know what you're doing and can fix it yourself.",
+	"abstract"   : "Career for Realism Overhaul. Select/install the Express Install first, and then select this mod when it asks you to pick between the current version or the legacy version.",
 	"license"    : "CC-BY-4.0",
 	"author"     : "RP-1 Group",
 	"$kref"      : "#/ckan/github/KSP-RO/RP-1",

--- a/RP-1.netkan
+++ b/RP-1.netkan
@@ -2,7 +2,7 @@
 	"spec_version" : "v1.26",
 	"identifier" : "RP-1",
 	"name"       : "Realistic Progression One (RP-1)",
-	"abstract"   : "Career for Realism Overhaul. Select/install the Express Install first, and then select this mod when it asks you to pick between the current version or the legacy version.",
+	"abstract"   : "Career for Realism Overhaul. Select/install the RP-1 Express Install first, and then select this when it asks you to pick between the current version or the legacy version.",
 	"license"    : "CC-BY-4.0",
 	"author"     : "RP-1 Group",
 	"$kref"      : "#/ckan/github/KSP-RO/RP-1",


### PR DESCRIPTION
The express install does not automatically select this install, but instead allows you to pick between this and legacy. This can lead to confusion, as seen in https://discord.com/channels/319857228905447436/512556137380315139/1152869006689181716.