### PR TITLE
Fix Active Program requirement in XPlanesHypersonic.cfg

### DIFF
--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesHypersonic.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesHypersonic.cfg
@@ -41,7 +41,7 @@ CONTRACT_TYPE
 	{
 		name = ProgramActive
 		type = ProgramActive
-		program = SuborbitalRocketplanes
+		program = EarlyXPlanes
 	}
 
 	BEHAVIOUR


### PR DESCRIPTION
Currently requires that non-existant program 'Suborbital Rocketplanes' is active