### PR TITLE
X-Planes tweaks

### DIFF
--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesHypersonicOptional.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesHypersonicOptional.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 
 	title = X-Planes (Hypersonic) Optional
 
-	description = <b>Program: X-Plane Research<br>Type: <color=green>Required</color></b><br><br>Design, build, and launch a crewed plane capable of hypersonic atmospheric flight of at least  @/minSpeedMPS km and return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.
+	description = <b>Program: X-Plane Research<br>Type: <color=blue>Optional</color></b><br><br>Design, build, and launch a crewed plane capable of hypersonic atmospheric flight of at least  @/minSpeedMPS km and return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.
 	genericDescription = Design, build, and launch a crewed rocket or plane to put a person into high atmosphere above a specific altitude and return home safely.
 
 	synopsis = Launch a crewed vessel to @/minSpeedMPS m/s below 40km altitude.
@@ -76,7 +76,7 @@ CONTRACT_TYPE
 	DATA
 	{
 		type = List<float>
-		minSpeedsMPS = [ 2500, 3000 ]
+		minSpeedsMPS = [ 2300, 2600 ]
 	}
 	
 	DATA

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesStratosphericResearch.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesStratosphericResearch.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 
 	title = X-Planes (Stratospheric Research)
 
-	description = <b>Program: X-Plane Research<br>Type: <color=blue>Optional</color></b><br><br>Future airliners may fly at unprecedented altitudes, and it is important to understand atmospheric behavior such as turbulence at high altitudes. In order to do this, design, build, and fly a crewed jet aircraft to maintain @VesselGroup/HoldSituation/minAltitude meters in level subsonic flight, then return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.
+	description = <b>Program: X-Plane Research<br>Type: <color=green>Required</color></b><br><br>Future airliners may fly at unprecedented altitudes, and it is important to understand atmospheric behavior such as turbulence at high altitudes. In order to do this, design, build, and fly a crewed jet aircraft to maintain @VesselGroup/HoldSituation/minAltitude meters in level subsonic flight, then return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.
 
 	genericDescription = Design, build, and fly a crewed jet aircraft to maintain a specific altitude, then return home safely.
 


### PR DESCRIPTION
Fix required/optional tags for new contracts, and reduce hypersonic requirements somewhat--it seems significantly harder than I remember it being to keep an X-15 cockpit intact at 3km/s, possibly a result of it getting the non-reentry-rated tag.