### PR TITLE
Minor fixes on X-Plane Program

### DIFF
--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesKarman.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesKarman.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 
 	title = X-Planes (Karman Line)
 
-	description = <b>Program: X-Plane Research<br>Type: <color=green>Required</color></b><br><br>Design, build, and launch a crewed rocket or plane to put a person into the high atmosphere above @/altitudeKm km and return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.<br><br><color=white><b>After this contract has been completed, the 'X-Planes (Suborbital)' contract will become available.</b></color>
+	description = <b>Program: X-Plane Research<br>Type: <color=red>CAPSTONE</color></b><br><br>Design, build, and launch a crewed rocket or plane to put a person into the high atmosphere above @/altitudeKm km and return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.<br><br><color=white><b>After this contract has been completed, the 'X-Planes (Suborbital)' contract will become available.</b></color>
 	genericDescription = Design, build, and launch a crewed rocket or plane to put a person into high atmosphere above a specific altitude and return home safely.
 
 	synopsis = Launch a crewed vessel to @/altitudeKm km.

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicOptionalHigh.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicOptionalHigh.cfg
@@ -25,7 +25,7 @@ CONTRACT_TYPE
 
 	targetBody = HomeWorld()
 
-	maxCompletions = 12
+	maxCompletions = 6
 	maxSimultaneous = 1
 	prestige = Trivial
 


### PR DESCRIPTION
...such as maxCompletions in Mach 2+ supersonic contracts, and contract type of the Karman line contract.

Somone might had forgotten that the total amount of speed records in Mach 2+ supersonic contracts had reduced to 6, while it might be helpful to mark the most challenging contract(s) of a program (Karman line in this case) as "Capstone", like the other programs did.