### PR TITLE
Fix contract confidence display with leader reputation affects

### DIFF
--- a/Source/Harmony/Contract.cs
+++ b/Source/Harmony/Contract.cs
@@ -58,8 +58,7 @@ namespace RP0.Harmony
 
             if (Programs.ProgramHandler.Instance != null && Programs.ProgramHandler.Instance.RepToConfidenceForContract(_contract, _isReward) is float repToConf && repToConf > 0f)
             {
-                double correctedRep = _contract.ReputationCompletion / CurrencyUtils.Rep(TransactionReasonsRP0.ContractReward, 1d);
-                var cmq = CurrencyModifierQueryRP0.RunQuery(TransactionReasonsRP0.ContractReward, 0d, 0d, 0d, correctedRep * repToConf, 0d);
+                var cmq = CurrencyModifierQueryRP0.RunQuery(TransactionReasonsRP0.ContractReward, 0d, 0d, 0d, _contract.ReputationCompletion * repToConf, 0d);
                 value += $"<color={CurrencyModifierQueryRP0.CurrencyColor(CurrencyRP0.Confidence)}>{CurrencyModifierQueryRP0.SpriteString(CurrencyRP0.Confidence)} {cmq.GetTotal(CurrencyRP0.Confidence):N0} {cmq.GetEffectDeltaText(CurrencyRP0.Confidence, "N0", CurrencyModifierQuery.TextStyling.OnGUI)}  </color>";
             }
             if (KerbalConstructionTime.PresetManager.Instance != null)


### PR DESCRIPTION
Noticed when taking Glushko as admin--standard-difficulty SR at 100% rewards showed as 48 confidence in admin, but provided the correct 50 when actually accepted and completed. It seems that the display was already using base rep. This was tested using Glushko--altitude SR gave increased reputation (11 after rounding) but 50 confidence in the new total, total confidence earned summary, MC contract summary, contract completion message,  and career log.