### PR TITLE
Ensure that reconstruct does not downsize the hangar

### DIFF
--- a/Source/KerbalConstructionTime/GUI/GUI_NewLC.cs
+++ b/Source/KerbalConstructionTime/GUI/GUI_NewLC.cs
@@ -64,9 +64,11 @@ namespace KerbalConstructionTime
 
         private static void SetFieldsFromVessel(BuildListVessel blv, LCItem lc = null)
         {
-            _newLCData.sizeMax.z = Mathf.Ceil(blv.ShipSize.z * 1.2f);
-            _newLCData.sizeMax.x = Mathf.Ceil(blv.ShipSize.x * 1.2f);
-            _newLCData.sizeMax.y = Mathf.Ceil(blv.ShipSize.y * 1.1f);
+            // Large hangars have no downsides, so don't reduce their size
+            var maintainSize = _newLCData.lcType != LaunchComplexType.Pad;
+            _newLCData.sizeMax.z = Mathf.Max(Mathf.Ceil(blv.ShipSize.z * 1.2f), maintainSize ? _newLCData.sizeMax.z : 0.0f);
+            _newLCData.sizeMax.x = Mathf.Max(Mathf.Ceil(blv.ShipSize.x * 1.2f), maintainSize ? _newLCData.sizeMax.x : 0.0f);
+            _newLCData.sizeMax.y = Mathf.Max(Mathf.Ceil(blv.ShipSize.y * 1.1f), maintainSize ? _newLCData.sizeMax.y : 0.0f);
             _newLCData.isHumanRated = blv.humanRated;
             if (lc == null)
             {


### PR DESCRIPTION
Unlike in LCs, the hangar does not pay maintenance for increases to maximum dimensions, and since they dictate maximum engineer count it's important not to downsize it unnecessarily. This is particularly so because many planes can use several times more engineers than a hangar built to their dimensions supports (https://discord.com/channels/319857228905447436/845457276641738782/1154214299078774834)--presently pressing "reconstruct" can cripple your ability to build the plane selected during reconstruction.

I've tested that this change provides what I believe to be the correct behavior--hangar reconstruction and upgrades upsize but do not downsize, while LC reconstruction downsizes but upgrades do not.