### PR TITLE
Remove flyby requirements for first mars and venus orbit

### DIFF
--- a/GameData/RP-1/Contracts/Mars/MarsOrbit.cfg
+++ b/GameData/RP-1/Contracts/Mars/MarsOrbit.cfg
@@ -46,13 +46,6 @@ CONTRACT_TYPE
 		program = EarlyInnerPlanetProbes
 	}
 
-	REQUIREMENT
-	{
-		name = CompleteContract
-		type = CompleteContract
-		contractType = flybyMars
-	}
-
 	// ************ DATA ************
 	DATA
 	{

--- a/GameData/RP-1/Contracts/Venus/VenusOrbit.cfg
+++ b/GameData/RP-1/Contracts/Venus/VenusOrbit.cfg
@@ -46,13 +46,6 @@ CONTRACT_TYPE
 		program = EarlyInnerPlanetProbes
 	}
 
-	REQUIREMENT
-	{
-		name = CompleteContract
-		type = CompleteContract
-		contractType = flybyVenus
-	}
-
 	// ************ DATA ************
 	DATA
 	{
@@ -93,7 +86,7 @@ CONTRACT_TYPE
 				name = Duration
 				type = Duration
 
-				duration = 120s
+				duration = 2m
 
 				preWaitText = Check for stable orbit
 				waitingText = Checking for stable orbit


### PR DESCRIPTION
Fix #2044 by removing the requirement to flyby mars or venus for their first orbit contract to show up. Also changed the "check for stable orbit" time in first venus orbit from 120s to 2m (which is what everywhere else is like) for consistency.