### PR TITLE
Lunar Orbiter & Mapper PE Max Updates

### DIFF
--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiter.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiter.cfg
@@ -45,7 +45,7 @@ CONTRACT_TYPE
 	{
 		type = float
 		minPe = 20000
-		maxPe = 225000
+		maxPe = 250000
 		maxAp = 500000
 	}
 

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiter.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiter.cfg
@@ -45,6 +45,7 @@ CONTRACT_TYPE
 	{
 		type = float
 		minPe = 20000
+		maxPe = 150000
 		maxAp = 500000
 	}
 
@@ -116,6 +117,7 @@ CONTRACT_TYPE
 			targetBody = Moon
 			situation = ORBITING
 			minPeA = @/minPe
+			maxPeA = @/maxPe
 			maxApA = @/maxAp
 			disableOnStateChange = true
 			

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiter.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiter.cfg
@@ -45,7 +45,7 @@ CONTRACT_TYPE
 	{
 		type = float
 		minPe = 20000
-		maxPe = 150000
+		maxPe = 225000
 		maxAp = 500000
 	}
 

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiterOptional.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiterOptional.cfg
@@ -53,7 +53,7 @@ CONTRACT_TYPE
 	{
 		type = float
 		minPe = 20000
-		maxPe = 225000
+		maxPe = 250000
 		maxAp = 500000
 	}
 

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiterOptional.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiterOptional.cfg
@@ -53,6 +53,7 @@ CONTRACT_TYPE
 	{
 		type = float
 		minPe = 20000
+		maxPe = 150000
 		maxAp = 500000
 	}
 
@@ -125,6 +126,7 @@ CONTRACT_TYPE
 			targetBody = Moon
 			situation = ORBITING
 			minPeA = @/minPe
+			maxPeA = @/maxPe
 			maxApA = @/maxAp
 			disableOnStateChange = true
 			

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiterOptional.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiterOptional.cfg
@@ -53,7 +53,7 @@ CONTRACT_TYPE
 	{
 		type = float
 		minPe = 20000
-		maxPe = 150000
+		maxPe = 225000
 		maxAp = 500000
 	}
 


### PR DESCRIPTION
First Lunar Orbiter & Mapper (Uncrewed) & the optional mission afterwards, requires you to collect visual imaging 2 (VI2) science from around the moon.  The current contract doesn't require any PE Max, however the biome science has to be collected from space low.  To see why I wasn't collecting the science, I had to reference 3 different materials:

- the contract requirements (to see it was biome specific), 
- the Science window (too see that biome science only comes from low orbit), 
- and the wiki to see where "space low" started

In talks with the dev-feedback channel in discord, someone pointed out that someone else on the discord had to "cheat" their way to completing the contract because they weren't collecting the science, and assumed it's because they were in "space high" since you can complete the orbit requirements without ever dipping into space low.  This PR is an attempt to bring the orbit requirements of the contract in line with the altitude requirements for the science.

Alternative: We could also lower the AP requirements to 150KM so they were completely in space low, but that may be more constrictive than the contract intends to be.

DISCLAIMER: I have not tested these changes and only assume this will edit the contract properly.  Please advise if I need to change this (or feel free to do so yourself)