### PR TITLE
Configure new reactor parts, better reactor ECMs

### DIFF
--- a/GameData/RP-1/Tree/ECM-Parts.cfg
+++ b/GameData/RP-1/Tree/ECM-Parts.cfg
@@ -463,8 +463,12 @@
     RO-reactor-BES5 = 100000,PowerReactors
     RO-reactor-TOPAZI = 200000,PowerReactors
     RO-reactor-kilopower = 10000,RO-reactor-snap10a
+    RO-reactor-prometheus = 1000000,RO-reactor-snap50-300
     RO-reactor-snap10a = 15000,PowerReactors
+    RO-reactor-snap2 = 10000,RO-reactor-snap10a,TurbineReactors
     RO-reactor-snap50 = 300000,TurbineReactors
+    RO-reactor-snap50-300 = 200000,RO-reactor-snap50
+    RO-reactor-snap8 = 105000,RO-reactor-snap10a
     ROAJ10-137 = AJ10-137
     ROAdvCapsule = capsulesGemini
     ROAerobeeSustainer = WAC-Corporal
@@ -1569,9 +1573,9 @@
     radiator-universal-1 = 1
     radiator-universal-2 = 1
     radiator-universal-3 = 1
-    reactor-0625 = 500000, RO-reactor-snap50
+    reactor-0625 = 500000,RO-reactor-snap50-300
     reactor-125 = 75000, RO-reactor-TOPAZI
-    reactor-25 = 400000, RO-reactor-snap50
+    reactor-25 = 400000,RO-reactor-snap8
     restock-decoupler-radial-tiny-1 = 1
     restock-engine-125-pug = Aestus
     restock-engine-125-valiant = Viking-2
@@ -1672,7 +1676,7 @@
     roverWheel2 = wheelsEarly
     roverWheel3 = wheelsLate
     rtg = 50000,RTGlevel4
-    rtg-0625 = 100000,RTGlevel6
+    rtg-0625 = 35156,RTGlevel6
     rtgMini = 50000,RTGlevel1
     s1-dp = 17000,dockingProbeDrogue,dockingCrew
     s1-lsolar = 7k-ok-lsolar

--- a/GameData/RP-1/Tree/EntryCostModifiers.cfg
+++ b/GameData/RP-1/Tree/EntryCostModifiers.cfg
@@ -636,6 +636,14 @@ ENTRYCOSTMODS
 //  NUCLEAR
 //	* RTG's will progress in tiers in order to reduce the entry costs
 //**********************************************************************************
+//	sources:
+//	https://www.osti.gov/biblio/4110379
+//	SNAP-50 reactor program cost ~21M USD/year (1965$)
+//	https://www.osti.gov/biblio/4101005
+//	SNAP-50 power conversion program cost ~13M USD/year (1965$)
+//	https://apps.dtic.mil/dtic/tr/fulltext/u2/a146831.pdf
+//	500M to 1B USD estimated to produce and test SNAP-50
+
 	// RTG
 	RTGlevel1 = 57550				// tech = firstRTG
 	RTGlevel2 = 5660, RTGlevel1		// tech = earlyRTG
@@ -645,10 +653,10 @@ ENTRYCOSTMODS
 	RTGlevel6 = 6970, RTGlevel5		// tech = modernNuclearPower
 	
 	// Nuclear Reactors
-	SpaceReactors = 1000000
-	PowerReactors = 50000, SpaceReactors, RTGlevel1		//For thermoelectrics
-	TurbineReactors = 100000, PowerReactors		//more complex Rankine/Brayton Cycle power reactors
-	LiquidCoreReactors = 1000000, SpaceReactors
+	SpaceReactors = 126000	// Assuming same yearly cost as SNAP-50, and first-gen reactors (SNAP-10, BES-5) were developed in around 6 years. 21M/year*6 years = ~126M USD, 126000 funds
+	PowerReactors = 10000, SpaceReactors, RTGlevel1		//For thermoelectrics
+	TurbineReactors = 130000, PowerReactors		//more complex Rankine/Brayton Cycle power reactors. SNAP-2 took about 10 years to develop power conversion unit, SNAP-50 would have been around 15? 13M/year*10 year = 130M, 130000 funds
+	FluidCoreReactors = 1000000, SpaceReactors		//cover the gas-core stuff if anyone adds that I guess
 
 
 //**********************************************************************************

--- a/GameData/RP-1/Tree/TREE-Parts.cfg
+++ b/GameData/RP-1/Tree/TREE-Parts.cfg
@@ -7237,6 +7237,14 @@
     %MODULE[ModuleTagList] { tag = Nuclear }
 
 }
+@PART[RO-reactor-prometheus]:FOR[xxxRP0]
+{
+    %TechRequired = modernNuclearPower
+    %cost = 24000
+    %entryCost = 0
+    RP0conf = true
+    @description ^=:$: <b><color=green>From Near Future Electrical mod</color></b>
+}
 @PART[RO-reactor-snap10a]:FOR[xxxRP0]
 {
     %TechRequired = nuclearFissionReactors
@@ -7248,10 +7256,43 @@
     %MODULE[ModuleTagList] { tag = Nuclear }
 
 }
+@PART[RO-reactor-snap2]:FOR[xxxRP0]
+{
+    %TechRequired = improvedRTG
+    %cost = 5000
+    %entryCost = 0
+    RP0conf = true
+    @description ^=:$: <b><color=green>From Near Future Electrical mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = Nuclear }
+
+}
 @PART[RO-reactor-snap50]:FOR[xxxRP0]
 {
     %TechRequired = improvedRTG
+    %cost = 10000
+    %entryCost = 0
+    RP0conf = true
+    @description ^=:$: <b><color=green>From Near Future Electrical mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = Nuclear }
+
+}
+@PART[RO-reactor-snap50-300]:FOR[xxxRP0]
+{
+    %TechRequired = multihundredWattRTG
     %cost = 20000
+    %entryCost = 0
+    RP0conf = true
+    @description ^=:$: <b><color=green>From Near Future Electrical mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = Nuclear }
+
+}
+@PART[RO-reactor-snap8]:FOR[xxxRP0]
+{
+    %TechRequired = improvedRTG
+    %cost = 5000
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Near Future Electrical mod</color></b>
@@ -19436,6 +19477,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Universal Storage 2 mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = NuclearRTG }
+
 }
 @PART[USRadialTanks]:FOR[xxxRP0]
 {
@@ -29829,10 +29873,13 @@
 @PART[rtg-0625]:FOR[xxxRP0]
 {
     %TechRequired = modernNuclearPower
-    %cost = 20045
-    %entryCost = 200445
+    %cost = 3550
+    %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Near Future Electrical mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = NuclearRTG }
+
 }
 @PART[rtg100]:FOR[xxxRP0]
 {

--- a/Source/Tech Tree/Parts Browser/data/Near_Future_Electrical.json
+++ b/Source/Tech Tree/Parts Browser/data/Near_Future_Electrical.json
@@ -72,6 +72,27 @@
         ]
     },
     {
+        "name": "RO-reactor-prometheus",
+        "title": "Prometheus 200 KWe Nuclear Reactor",
+        "description": "",
+        "mod": "Near Future Electrical",
+        "cost": 24000,
+        "entry_cost": "0",
+        "category": "NUCLEAR",
+        "info": "Nuclear Reactor",
+        "year": "2016",
+        "technology": "modernNuclearPower",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "JIMO",
+        "engine_config": "",
+        "upgrade": false,
+        "entry_cost_mods": "1000000,RO-reactor-snap50-300",
+        "identical_part_name": "",
+        "module_tags": []
+    },
+    {
         "name": "RO-reactor-snap10a",
         "title": "NASA SNAP-10A Nuclear Reactor",
         "description": "",
@@ -96,12 +117,35 @@
         ]
     },
     {
-        "name": "RO-reactor-snap50",
-        "title": "NASA SNAP-50 Nuclear Reactor",
+        "name": "RO-reactor-snap2",
+        "title": "NASA SNAP-2 Nuclear Reactor",
         "description": "",
         "mod": "Near Future Electrical",
-        "cost": 20000,
-        "entry_cost": 0,
+        "cost": 5000,
+        "entry_cost": "0",
+        "category": "NUCLEAR",
+        "info": "Nuclear Reactor",
+        "year": "1967",
+        "technology": "improvedRTG",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "",
+        "upgrade": false,
+        "entry_cost_mods": "10000,RO-reactor-snap10a,TurbineReactors",
+        "identical_part_name": "",
+        "module_tags": [
+            "Nuclear"
+        ]
+    },
+    {
+        "name": "RO-reactor-snap50",
+        "title": "NASA SNAP-50 35 kWe Nuclear Reactor",
+        "description": "",
+        "mod": "Near Future Electrical",
+        "cost": 10000,
+        "entry_cost": "0",
         "category": "NUCLEAR",
         "info": "Nuclear Reactor",
         "year": "1975",
@@ -114,6 +158,52 @@
         "engine_config": "",
         "upgrade": false,
         "entry_cost_mods": "300000,TurbineReactors",
+        "identical_part_name": "",
+        "module_tags": [
+            "Nuclear"
+        ]
+    },
+    {
+        "name": "RO-reactor-snap50-300",
+        "title": "NASA SNAP-50 300 kWe Nuclear Reactor",
+        "description": "",
+        "mod": "Near Future Electrical",
+        "cost": 20000,
+        "entry_cost": "0",
+        "category": "NUCLEAR",
+        "info": "Nuclear Reactor",
+        "year": "1976",
+        "technology": "multihundredWattRTG",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "",
+        "upgrade": false,
+        "entry_cost_mods": "200000,RO-reactor-snap50",
+        "identical_part_name": "",
+        "module_tags": [
+            "Nuclear"
+        ]
+    },
+    {
+        "name": "RO-reactor-snap8",
+        "title": "NASA SNAP-8 Nuclear Reactor",
+        "description": "",
+        "mod": "Near Future Electrical",
+        "cost": 5000,
+        "entry_cost": "0",
+        "category": "NUCLEAR",
+        "info": "Nuclear Reactor",
+        "year": "1971",
+        "technology": "improvedRTG",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "",
+        "upgrade": false,
+        "entry_cost_mods": "105000,RO-reactor-snap10a",
         "identical_part_name": "",
         "module_tags": [
             "Nuclear"
@@ -225,7 +315,7 @@
         "spacecraft": "",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "500000, RO-reactor-snap50",
+        "entry_cost_mods": "500000,RO-reactor-snap50-300",
         "identical_part_name": "",
         "module_tags": [
             "Nuclear"
@@ -273,7 +363,7 @@
         "spacecraft": "",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "400000, RO-reactor-snap50",
+        "entry_cost_mods": "400000,RO-reactor-snap8",
         "identical_part_name": "",
         "module_tags": [
             "Nuclear"
@@ -308,8 +398,8 @@
         "title": "NASA & DOE Advanced Sterling RG",
         "description": "A much lighter and more efficient radioisotope generator by using the sterling cycle.",
         "mod": "Near Future Electrical",
-        "cost": 20045,
-        "entry_cost": 200445,
+        "cost": 3550,
+        "entry_cost": 0,
         "category": "NUCLEAR",
         "info": "RTG",
         "year": "2015",
@@ -322,8 +412,10 @@
         "spacecraft": "",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "100000,RTGlevel6",
+        "entry_cost_mods": "35156,RTGlevel6",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "NuclearRTG"
+        ]
     }
 ]

--- a/Source/Tech Tree/Parts Browser/data/Universal_Storage_2.json
+++ b/Source/Tech Tree/Parts Browser/data/Universal_Storage_2.json
@@ -793,7 +793,9 @@
         "upgrade": false,
         "entry_cost_mods": "RO-MMRTG",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "NuclearRTG"
+        ]
     },
     {
         "name": "USRadialTanks",


### PR DESCRIPTION
Configure SNAP-2, SNAP-8, SNAP-50 (300 kWe), and Prometheus from Near Future Electrical. Also adjust reactor ECMs to sane values based on SNAP-50 development costs.