### PR TITLE
Interplanetary contract issues

### DIFF
--- a/GameData/RP-1/Contracts/Mars/Mars Landing.cfg
+++ b/GameData/RP-1/Contracts/Mars/Mars Landing.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = MartianSurfaceExploration
 	agent = Surveys
 
-	description = <b>Program: Mars Surface Exploration<br>Type: <color=green>Required</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Mars and transmit a science report from the surface. This contract can be completed 2 times.
+	description = <b>Program: Mars Surface Exploration<br>Type: <color=green>Required</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Mars and transmit a science report from the surface.
 
 	synopsis = Send an uncrewed probe to land on Mars
 
@@ -18,7 +18,7 @@ CONTRACT_TYPE
 	autoAccept = false
 	minExpiry = 0
 	maxExpiry = 0
-	maxCompletions = 2
+	maxCompletions = 1
 	maxSimultaneous = 1
 	deadline = 0
 
@@ -51,7 +51,7 @@ CONTRACT_TYPE
 		name = VesselGroup
 		type = VesselParameterGroup
 		title = Uncrewed landing on Mars
-		
+
 		PARAMETER
 		{
 			name = NewVessel

--- a/GameData/RP-1/Contracts/Mars/Mars LandingRepeat.cfg
+++ b/GameData/RP-1/Contracts/Mars/Mars LandingRepeat.cfg
@@ -1,28 +1,30 @@
 CONTRACT_TYPE
 {
-	name = landingCharon
-	title = Charon Landing
-	group = PlutoLandings
+	name = landingMarsRepeatable
+	title = Mars Landing
+	group = MartianSurfaceExploration
 	agent = Surveys
 
-	description = <b>Program: Plutonian Landings<br>Type: <color=green>Required</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Charon and transmit a science report from the surface.
+	description = <b>Program: Mars Surface Exploration<br>Type: <color=blue>Optional</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Mars and transmit a science report from the surface. This contract can be completed as many times as you wish.
 
-	synopsis = Send an uncrewed probe to land on Charon
+	synopsis = Send an uncrewed probe to land on Mars
 
 	completedMessage = Congratulations! Landing a probe on another planetary body in our system is no easy feat! The science gathered from this lander will unlock some of the secrets of our Solar System.
 
-	sortKey = 1217
+	sortKey = 1201
 
 	cancellable = true
 	declinable = true
 	autoAccept = false
 	minExpiry = 0
 	maxExpiry = 0
-	maxCompletions = 1
+	maxCompletions = 0
 	maxSimultaneous = 1
 	deadline = 0
 
-	targetBody = Charon
+	targetBody = Mars
+
+
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
@@ -30,8 +32,8 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 900
-	failureReputation = 0 // was @rewardReputation
+	rewardReputation = 400	// was 40
+	failureReputation = 0 // was @rewardReputation	// was 50
 
 	// ************ REQUIREMENTS ************
 
@@ -39,7 +41,13 @@ CONTRACT_TYPE
 	{
 		name = ProgramActive
 		type = ProgramActive
-		program = PlutoLandings
+		program = MarsSurfaceExp
+	}
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = landingMars
 	}
 
 	// ************ PARAMETERS ************
@@ -48,7 +56,7 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Uncrewed landing on Charon
+		title = Uncrewed landing on Mars
 
 		PARAMETER
 		{
@@ -73,7 +81,7 @@ CONTRACT_TYPE
 			situation = LANDED
 			situation = SPLASHED
 			disableOnStateChange = true
-			title = Safely land on Charon
+			title = Safely land on Mars
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-1/Contracts/Mars/Mars RoverRepeat.cfg
+++ b/GameData/RP-1/Contracts/Mars/Mars RoverRepeat.cfg
@@ -1,28 +1,30 @@
 CONTRACT_TYPE
 {
-	name = roverTitan
-	title = Titan Rover
-	group = SaturnObservation
+	name = roverMarsRepeatable
+	title = Mars Rover
+	group = MartianSurfaceExploration
 	agent = Federation Aeronautique Internationale
 
-	description = <b>Program: Saturn Observation<br>Type: <color=blue>Optional</color></b><br><br>Design and send a rover to the surface of Titan and visit the different areas marked by our scientists.&br;&br;We suggest landing your rover as close as possible to the first marker.
+	description = <b>Program: Mars Surface Exploration<br>Type: <color=blue>Optional</color></b><br><br>Design and send a rover to the surface of Mars and visit the different areas marked by our scientists.&br;&br;We suggest landing your rover as close as possible to the first marker.
 
-	synopsis = Send a rover to explore the surface of Titan
+	synopsis = Send a rover to explore the surface of Mars
 
 	completedMessage = Congratulations, our rover has returned important scientific data.
 
-	sortKey = 1314
+	sortKey = 1301
 
 	cancellable = true
 	declinable = true
 	autoAccept = false
 	minExpiry = 0
 	maxExpiry = 0
-	maxCompletions = 1
+	maxCompletions = 0
 	maxSimultaneous = 1
 	deadline = 0
 
-	targetBody = Titan
+	targetBody = Mars
+
+
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
@@ -30,29 +32,16 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 800
-	failureReputation = 0 // was @rewardReputation
+	rewardReputation = 500	// was 50
+	failureReputation = 0 // was @rewardReputation	// was 60
 
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT
 	{
-		name = Any
-		type = Any
-
-		REQUIREMENT
-		{
-			name = ProgramActive
-			type = ProgramActive
-			program = SaturnMoonLandings
-		}
-
-		REQUIREMENT
-		{
-			name = ProgramActive
-			type = ProgramActive
-			program = SaturnObservation
-		}
+		name = ProgramActive
+		type = ProgramActive
+		program = MarsSurfaceExp
 	}
 
 	REQUIREMENT
@@ -60,7 +49,14 @@ CONTRACT_TYPE
 		name = TechResearched
 		type = TechResearched
 		tech = lunarRatedHeatshields
-		title = Have Unlocked the Lunar Rated Heatshields Technology for rover wheels
+		title = Have Unlocked the Lunar Rated Heatshields Technology for Rover Wheels
+	}
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = roverMars
 	}
 
 	// ************ PARAMETERS ************
@@ -69,8 +65,8 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Uncrewed landing on Titan
-		define = ProbeTitan
+		title = Uncrewed rover on Mars
+		define = ProbeMars
 
 		PARAMETER
 		{
@@ -88,7 +84,7 @@ CONTRACT_TYPE
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Safely land near rover site Alpha on Titan
+			title = Safely land near rover site Alpha on Mars
 			hideChildren = true
 			showMessages = true
 		}

--- a/GameData/RP-1/Contracts/Mercury Exploration/Mercury Landing.cfg
+++ b/GameData/RP-1/Contracts/Mercury Exploration/Mercury Landing.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = MercuryExploration
 	agent = Surveys
 
-	description = <b>Program: Mercury Exploration<br>Type: <color=red>CAPSTONE</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Mercury and transmit a science report from the surface. This contract can be completed 2 times.
+	description = <b>Program: Mercury Exploration<br>Type: <color=red>CAPSTONE</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Mercury and transmit a science report from the surface.
 
 	synopsis = Send an uncrewed probe to land on Mercury
 
@@ -18,7 +18,7 @@ CONTRACT_TYPE
 	autoAccept = false
 	minExpiry = 0
 	maxExpiry = 0
-	maxCompletions = 2
+	maxCompletions = 1
 	maxSimultaneous = 1
 	deadline = 0
 
@@ -30,8 +30,8 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 700	
-	failureReputation = 0 // was @rewardReputation	
+	rewardReputation = 700
+	failureReputation = 0 // was @rewardReputation
 
 	// ************ REQUIREMENTS ************
 
@@ -41,13 +41,13 @@ CONTRACT_TYPE
 		type = ProgramActive
 		program = MercuryExploration
 	}
-	
-	EQUIREMENT
+
+	REQUIREMENT
 	{
 		name = CompleteContract
 		type = CompleteContract
 		contractType = orbitMercury
-		
+
 	}
 
 	// ************ PARAMETERS ************
@@ -57,7 +57,7 @@ CONTRACT_TYPE
 		name = VesselGroup
 		type = VesselParameterGroup
 		title = Uncrewed landing on Mercury
-		
+
 		PARAMETER
 		{
 			name = NewVessel

--- a/GameData/RP-1/Contracts/Mercury Exploration/Mercury LandingRepeat.cfg
+++ b/GameData/RP-1/Contracts/Mercury Exploration/Mercury LandingRepeat.cfg
@@ -1,28 +1,28 @@
 CONTRACT_TYPE
 {
-	name = landingCharon
-	title = Charon Landing
-	group = PlutoLandings
+	name = landingMercuryRepeatable
+	title = Mercury Landing
+	group = MercuryExploration
 	agent = Surveys
 
-	description = <b>Program: Plutonian Landings<br>Type: <color=green>Required</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Charon and transmit a science report from the surface.
+	description = <b>Program: Mercury Exploration<br>Type: <color=blue>Optional</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Mercury and transmit a science report from the surface.
 
-	synopsis = Send an uncrewed probe to land on Charon
+	synopsis = Send an uncrewed probe to land on Mercury
 
 	completedMessage = Congratulations! Landing a probe on another planetary body in our system is no easy feat! The science gathered from this lander will unlock some of the secrets of our Solar System.
 
-	sortKey = 1217
+	sortKey = 1202
 
 	cancellable = true
 	declinable = true
 	autoAccept = false
 	minExpiry = 0
 	maxExpiry = 0
-	maxCompletions = 1
+	maxCompletions = 0
 	maxSimultaneous = 1
 	deadline = 0
 
-	targetBody = Charon
+	targetBody = Mercury
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
@@ -30,7 +30,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 900
+	rewardReputation = 600
 	failureReputation = 0 // was @rewardReputation
 
 	// ************ REQUIREMENTS ************
@@ -39,7 +39,14 @@ CONTRACT_TYPE
 	{
 		name = ProgramActive
 		type = ProgramActive
-		program = PlutoLandings
+		program = MercuryExploration
+	}
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = landingMercury
 	}
 
 	// ************ PARAMETERS ************
@@ -48,7 +55,7 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Uncrewed landing on Charon
+		title = Uncrewed landing on Mercury
 
 		PARAMETER
 		{
@@ -73,7 +80,7 @@ CONTRACT_TYPE
 			situation = LANDED
 			situation = SPLASHED
 			disableOnStateChange = true
-			title = Safely land on Charon
+			title = Safely land on Mercury
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-1/Contracts/Plutonian Landings/Charon LandingRepeatable.cfg
+++ b/GameData/RP-1/Contracts/Plutonian Landings/Charon LandingRepeatable.cfg
@@ -1,6 +1,6 @@
 CONTRACT_TYPE
 {
-	name = landingCharon
+	name = landingCharonRepeat
 	title = Charon Landing
 	group = PlutoLandings
 	agent = Surveys
@@ -18,7 +18,7 @@ CONTRACT_TYPE
 	autoAccept = false
 	minExpiry = 0
 	maxExpiry = 0
-	maxCompletions = 1
+	maxCompletions = 0
 	maxSimultaneous = 1
 	deadline = 0
 
@@ -40,6 +40,12 @@ CONTRACT_TYPE
 		name = ProgramActive
 		type = ProgramActive
 		program = PlutoLandings
+	}
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = landingCharon
 	}
 
 	// ************ PARAMETERS ************

--- a/GameData/RP-1/Contracts/Plutonian Landings/Pluto Landing.cfg
+++ b/GameData/RP-1/Contracts/Plutonian Landings/Pluto Landing.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = PlutoLandings
 	agent = Surveys
 
-	description = <b>Program: Plutonian Landings<br>Type: <color=green>Required</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Pluto and transmit a science report from the surface. This contract can be completed 2 times.
+	description = <b>Program: Plutonian Landings<br>Type: <color=green>Required</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Pluto and transmit a science report from the surface. 
 
 	synopsis = Send an uncrewed probe to land on Pluto
 
@@ -18,7 +18,7 @@ CONTRACT_TYPE
 	autoAccept = false
 	minExpiry = 0
 	maxExpiry = 0
-	maxCompletions = 2
+	maxCompletions = 1
 	maxSimultaneous = 1
 	deadline = 0
 
@@ -30,8 +30,8 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 900	
-	failureReputation = 0 // was @rewardReputation	
+	rewardReputation = 900
+	failureReputation = 0 // was @rewardReputation
 
 	// ************ REQUIREMENTS ************
 
@@ -49,7 +49,7 @@ CONTRACT_TYPE
 		name = VesselGroup
 		type = VesselParameterGroup
 		title = Uncrewed landing on Pluto
-		
+
 		PARAMETER
 		{
 			name = NewVessel

--- a/GameData/RP-1/Contracts/Plutonian Landings/Pluto LandingRepeatable.cfg
+++ b/GameData/RP-1/Contracts/Plutonian Landings/Pluto LandingRepeatable.cfg
@@ -1,28 +1,28 @@
 CONTRACT_TYPE
 {
-	name = landingCharon
-	title = Charon Landing
+	name = landingPlutoRepeat
+	title = Pluto Landing
 	group = PlutoLandings
 	agent = Surveys
 
-	description = <b>Program: Plutonian Landings<br>Type: <color=green>Required</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Charon and transmit a science report from the surface.
+	description = <b>Program: Plutonian Landings<br>Type: <color=green>Required</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Pluto and transmit a science report from the surface.
 
-	synopsis = Send an uncrewed probe to land on Charon
+	synopsis = Send an uncrewed probe to land on Pluto
 
 	completedMessage = Congratulations! Landing a probe on another planetary body in our system is no easy feat! The science gathered from this lander will unlock some of the secrets of our Solar System.
 
-	sortKey = 1217
+	sortKey = 1203
 
 	cancellable = true
 	declinable = true
 	autoAccept = false
 	minExpiry = 0
 	maxExpiry = 0
-	maxCompletions = 1
+	maxCompletions = 0
 	maxSimultaneous = 1
 	deadline = 0
 
-	targetBody = Charon
+	targetBody = Pluto
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
@@ -41,6 +41,12 @@ CONTRACT_TYPE
 		type = ProgramActive
 		program = PlutoLandings
 	}
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = landingPluto
+	}
 
 	// ************ PARAMETERS ************
 
@@ -48,7 +54,7 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Uncrewed landing on Charon
+		title = Uncrewed landing on Pluto
 
 		PARAMETER
 		{
@@ -73,7 +79,7 @@ CONTRACT_TYPE
 			situation = LANDED
 			situation = SPLASHED
 			disableOnStateChange = true
-			title = Safely land on Charon
+			title = Safely land on Pluto
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-1/Contracts/Saturn Observation/Titan Rover.cfg
+++ b/GameData/RP-1/Contracts/Saturn Observation/Titan Rover.cfg
@@ -37,22 +37,9 @@ CONTRACT_TYPE
 
 	REQUIREMENT
 	{
-		name = Any
-		type = Any
-
-		REQUIREMENT
-		{
-			name = ProgramActive
-			type = ProgramActive
-			program = SaturnMoonLandings
-		}
-
-		REQUIREMENT
-		{
-			name = ProgramActive
-			type = ProgramActive
-			program = SaturnObservation
-		}
+		name = ProgramActive
+		type = ProgramActive
+		program = SaturnMoonLandings
 	}
 
 	REQUIREMENT

--- a/GameData/RP-1/Contracts/Venus/Venus Landing.cfg
+++ b/GameData/RP-1/Contracts/Venus/Venus Landing.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = VenusSurfaceExp
 	agent = Surveys
 
-	description = <b>Program: Venus Surface Exploration<br>Type: <color=red>Capstone</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Venus and transmit a science report from the surface. This contract can be completed 2 times.&br;&br;It is very hot on Venus, so please be sure to account for this in the type of parachutes you choose to pack.
+	description = <b>Program: Venus Surface Exploration<br>Type: <color=red>Capstone</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Venus and transmit a science report from the surface. &br;&br;It is very hot on Venus, so please be sure to account for this in the type of parachutes you choose to pack.
 
 	synopsis = Send an uncrewed probe to land on Venus
 
@@ -18,7 +18,7 @@ CONTRACT_TYPE
 	autoAccept = false
 	minExpiry = 0
 	maxExpiry = 0
-	maxCompletions = 2
+	maxCompletions = 1
 	maxSimultaneous = 1
 	deadline = 0
 
@@ -30,8 +30,8 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 500	
-	failureReputation = 0 // was @rewardReputation	
+	rewardReputation = 500
+	failureReputation = 0 // was @rewardReputation
 
 	// ************ REQUIREMENTS ************
 
@@ -49,7 +49,7 @@ CONTRACT_TYPE
 		name = VesselGroup
 		type = VesselParameterGroup
 		title = Uncrewed landing on Venus
-		
+
 		PARAMETER
 		{
 			name = NewVessel

--- a/GameData/RP-1/Contracts/Venus/Venus LandingRepeat.cfg
+++ b/GameData/RP-1/Contracts/Venus/Venus LandingRepeat.cfg
@@ -1,28 +1,28 @@
 CONTRACT_TYPE
 {
-	name = landingCharon
-	title = Charon Landing
-	group = PlutoLandings
+	name = landingVenusRepeatable
+	title = Venus Landing
+	group = VenusSurfaceExp
 	agent = Surveys
 
-	description = <b>Program: Plutonian Landings<br>Type: <color=green>Required</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Charon and transmit a science report from the surface.
+	description = <b>Program: Venus Surface Exploration<br>Type: <color=blue>Optional</color></b><br><br>Design and successfully launch an uncrewed probe that will soft land on Venus and transmit a science report from the surface. &br;&br;It is very hot on Venus, so please be sure to account for this in the type of parachutes you choose to pack.
 
-	synopsis = Send an uncrewed probe to land on Charon
+	synopsis = Send an uncrewed probe to land on Venus
 
 	completedMessage = Congratulations! Landing a probe on another planetary body in our system is no easy feat! The science gathered from this lander will unlock some of the secrets of our Solar System.
 
-	sortKey = 1217
+	sortKey = 1200
 
 	cancellable = true
 	declinable = true
 	autoAccept = false
 	minExpiry = 0
 	maxExpiry = 0
-	maxCompletions = 1
+	maxCompletions = 0
 	maxSimultaneous = 1
 	deadline = 0
 
-	targetBody = Charon
+	targetBody = Venus
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
@@ -30,7 +30,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 900
+	rewardReputation = 400
 	failureReputation = 0 // was @rewardReputation
 
 	// ************ REQUIREMENTS ************
@@ -39,7 +39,13 @@ CONTRACT_TYPE
 	{
 		name = ProgramActive
 		type = ProgramActive
-		program = PlutoLandings
+		program = VenusSurfaceExp
+	}
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = landingVenus
 	}
 
 	// ************ PARAMETERS ************
@@ -48,7 +54,7 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Uncrewed landing on Charon
+		title = Uncrewed landing on Venus
 
 		PARAMETER
 		{
@@ -73,7 +79,7 @@ CONTRACT_TYPE
 			situation = LANDED
 			situation = SPLASHED
 			disableOnStateChange = true
-			title = Safely land on Charon
+			title = Safely land on Venus
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-1/Contracts/Venus/Venus LandingRepeat.cfg
+++ b/GameData/RP-1/Contracts/Venus/Venus LandingRepeat.cfg
@@ -30,7 +30,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 400
+	rewardReputation = 200
 	failureReputation = 0 // was @rewardReputation
 
 	// ************ REQUIREMENTS ************

--- a/GameData/RP-1/Contracts/Venus/VenusOrbitRepeat.cfg
+++ b/GameData/RP-1/Contracts/Venus/VenusOrbitRepeat.cfg
@@ -32,7 +32,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 350
+	rewardReputation = 200
 	failureReputation = 0 // was @rewardReputation
 
 

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -44,7 +44,7 @@ RP0_PROGRAM
 			name = XPlanesKarman
 		}
 	}
-
+	
 	OPTIONALS
 	{
 		XPlanesSupersonicOptionalLow = true
@@ -55,7 +55,7 @@ RP0_PROGRAM
 		XPlanesSuborbital = true
 		XPlanesHypersonicOptional = true
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 350
@@ -83,13 +83,13 @@ RP0_PROGRAM
 		complete_contract = DownrangeEarly
 		complete_contract = Downrange
 	}
-
+	
 	OPTIONALS
 	{
 		DownrangeSoundingIntermediate = true
 		DistanceSoundingDifficult = true
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 150
@@ -116,23 +116,23 @@ RP0_PROGRAM
 		{
 			name = KarmanLine
 		}
-
+		
 		COMPLETE_CONTRACT
 		{
 			name = SoundingRocketFilm
 		}
-
+		
 		COMPLETE_CONTRACT
 		{
 			name = SoundingRocketBio
 		}
-
+		
 		COMPLETE_CONTRACT
 		{
 			name = SoundingRocketAdvancedBio
 		}
 	}
-
+	
 	OPTIONALS
 	{
 		SoundingDifficult = true
@@ -141,7 +141,7 @@ RP0_PROGRAM
 		SoundingRocketBioOptional = true
 		SoundingRocketAdvancedBioOptional = true
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 150
@@ -237,13 +237,13 @@ RP0_PROGRAM
 	{
 		EarlySatellites = true
 	}
-
+	
 	OPTIONALS
 	{
 		Downrange6000-Heavy = true
 		Downrange7500-Heavy = true
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 600
@@ -283,7 +283,7 @@ RP0_PROGRAM
 		complete_contract = FirstMolniyaSat
 		complete_contract = FirstTundraSat
 	}
-
+	
 	OPTIONALS
 	{
 		ComTestSat = true
@@ -300,7 +300,7 @@ RP0_PROGRAM
 {
 	name = EarthObservationScience1
 	title = Early Earth Observation Satellites
-	description = Now that you have proven the ability to send satellites into orbit, the next step is to send them into more useful orbits with more beneficial payloads. This program will focus on satellites for observing the Earth and the space environment around it. This will advance scientific knowledge of not just physical processes within our atmosphere, but also those in space, all of which influence our lives here on Earth.
+	description = Now that you have proven the ability to send satellites into orbit, the next step is to send them into more useful orbits with more beneficial payloads. This program will focus on satellites for observing the Earth and the space environment around it. This will advance scientific knowledge of not just physical processes within our atmosphere, but also those in space, all of which influence our lives here on Earth. 
 	requirementsPrettyText = Complete Early Satellites program
 	objectivesPrettyText = Launch satellites to photograph the Earth, analyze weather, measure solar wind and cosmic rays, and determine the extent of the Magnetosphere.
 	nominalDurationYears = 4
@@ -328,7 +328,7 @@ RP0_PROGRAM
 		complete_contract = first_OrbitRecover
 		complete_contract = EOSCorona
 	}
-
+	
 	OPTIONALS
 	{
 		EOSGrav1 = true
@@ -348,9 +348,9 @@ RP0_PROGRAM
 {
 	name = CommercialApplications1
 	title = Early Commercial Applications
-	description = Although the earliest satellites were launched through government programs, commercial uses had been envisioned for a long time. Through this program, you will launch the earliest iterations of commercial-use satellites. With wildly varying needs, each satellite is dedicated to a specific requirement, typically with far more focused requirements than the earlier, broader scientific satellites.
+	description = Although the earliest satellites were launched through government programs, commercial uses had been envisioned for a long time. Through this program, you will launch the earliest iterations of commercial-use satellites. With wildly varying needs, each satellite is dedicated to a specific requirement, typically with far more focused requirements than the earlier, broader scientific satellites. 
 	requirementsPrettyText = Complete Early Satellites program
-	objectivesPrettyText = Launch the first commercial-use satellites and build a satellite communication network.
+	objectivesPrettyText = Launch the first commercial-use satellites and build a satellite communication network. 
 	nominalDurationYears = 4
 	baseFunding = 560000
 	fundingCurve = MildRampupCurve
@@ -382,7 +382,7 @@ RP0_PROGRAM
 			complete_contract = EarlyComNetwork4-CA
 		}
 	}
-
+	
 	OPTIONALS
 	{
 		EarlyComSat-CA = true
@@ -429,7 +429,7 @@ RP0_PROGRAM
 			complete_contract = EarlyComNetwork4
 		}
 	}
-
+	
 	OPTIONALS
 	{
 		ComTestSat = true
@@ -446,7 +446,7 @@ RP0_PROGRAM
 RP0_PROGRAM
 {
 	name = GEOCommNetwork
-	title = Geostationary Communication Network
+	title = Geostationary Communication Network 
 	description = With geostationary orbits, satellites can be placed at specific spots over the equator where they will stay. This allows communications satellites to be put exactly where they will have the greatest benefit. This program tasks you with creating a 4-satellite Geostationary Network for communication. Each satellite will require 315 units of ComSatPayload.
 	requirementsPrettyText = Complete the Targeted Satellites Program
 	objectivesPrettyText = Complete the Geostationary Communications Network.
@@ -470,12 +470,12 @@ RP0_PROGRAM
 	{
 		complete_contract = GeoComSatNetwork
 	}
-
+	
 	OPTIONALS
 	{
 		GEORepeatComSats = true
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 450
@@ -496,7 +496,7 @@ RP0_PROGRAM
 	slots = 2
 
 	REQUIREMENTS
-	{
+	{	
 		ANY
 		{
 			complete_contract = FirstScienceSat
@@ -520,13 +520,13 @@ RP0_PROGRAM
 		complete_contract = LunarImpactor
 		complete_contract = LunarOrbiter
 	}
-
+	
 	OPTIONALS
 	{
 		LunarImpactorOptional = true
 		LunarOrbiterOptional = true
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 550
@@ -538,7 +538,7 @@ RP0_PROGRAM
 {
 	name = UncrewedLunarSurface
 	title = Uncrewed Lunar Surface Exploration
-	description = Landing uncrewed probes on the Moon is the next step in exploring the Solar System. Successfully landing on the Moon is a difficult problem to solve. You will need to develop even more capable launch vehicles to be able to launch a large enough payload. These uncrewed landings will give you the data you need to plan for your crewed landings to follow. You will need to research deeply-throttleable engines from the Early Landing node (recommended) or figure out how to perform a landing with RCS.
+	description = Landing uncrewed probes on the Moon is the next step in exploring the Solar System. Successfully landing on the Moon is a difficult problem to solve. You will need to develop even more capable launch vehicles to be able to launch a large enough payload. These uncrewed landings will give you the data you need to plan for your crewed landings to follow. You will need to research deeply-throttleable engines from the Early Landing node (recommended) or figure out how to perform a landing with RCS. 
 	requirementsPrettyText = Complete the Early Lunar Probes program
 	objectivesPrettyText = Land probes on the Moon.
 	nominalDurationYears = 5
@@ -560,7 +560,7 @@ RP0_PROGRAM
 		complete_contract = MoonOrbiter
 		complete_contract = MoonLandingFarSide
 	}
-
+	
 	OPTIONALS
 	{
 		MoonLandingOptional = true
@@ -569,7 +569,7 @@ RP0_PROGRAM
 		MoonRover = true
 		MoonLandingReturn = true
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 900
@@ -593,7 +593,7 @@ RP0_PROGRAM
 	repPenaltyPerYearLate = 895
 	repToConfidence = 3
 	slots = 3
-
+	
 	REQUIREMENTS
 	{
 		ANY
@@ -617,7 +617,7 @@ RP0_PROGRAM
 		complete_contract = Rendezvous
 		complete_contract = first_Docking
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 2400
@@ -651,7 +651,7 @@ RP0_PROGRAM
 	repPenaltyPerYearLate = 315
 	repToConfidence = 3
 	slots = 3
-
+	
 	REQUIREMENTS
 	{
 		ANY
@@ -673,7 +673,7 @@ RP0_PROGRAM
 		complete_contract = first_OrbitCrewed
 		complete_contract = CollectCrewedScienceBasic
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 800
@@ -707,7 +707,7 @@ RP0_PROGRAM
 	repPenaltyPerYearLate = 575
 	repToConfidence = 3
 	slots = 3
-
+	
 	REQUIREMENTS
 	{
 		complete_program = CrewedOrbitEarly
@@ -724,7 +724,7 @@ RP0_PROGRAM
 		complete_contract = Rendezvous
 		complete_contract = first_Docking
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 1450
@@ -777,7 +777,7 @@ RP0_PROGRAM
 		OrbitalPlane3 = true
 		CrewedSpaceplaneSuborbital = true
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 2500
@@ -788,7 +788,7 @@ RP0_PROGRAM
 RP0_PROGRAM
 {
 	name = EarlyInnerPlanetProbes
-	title = Early Inner Planet Probes
+	title = Early Inner Planet Probes 
 	description = This program tasks you with exploring Venus and Mars. Though these may be Earth's closest neighbors, the distance between us and them still averages in the hundreds of millions of kilometers. Staying in contact with these probes will require advances in communication technology. Maintaining functionality and power over such great distances and long times will present new challenges in spacecraft design.
 	requirementsPrettyText = Complete contracts X and Y
 	objectivesPrettyText = Orbit Venus and Mars.
@@ -816,13 +816,13 @@ RP0_PROGRAM
 		complete_contract = orbitMars
 		complete_contract = orbitVenus
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 1300
 		Fast = 2600
 	}
-
+	
 	OPTIONALS
 	{
 		MarsOrbitRepeatable = true
@@ -837,7 +837,7 @@ RP0_PROGRAM
 	title = Crewed Lunar Exploration
 	description = You are tasked with sending to the Moon, 240,000 miles away from the control station in Houston, a giant rocket more than 300 feet tall, made of new metal alloys, some of which have not yet been invented, capable of standing heat and stresses several times more than have ever been experienced, fitted together with a precision better than the finest watch, carrying all the equipment needed for propulsion, guidance, control, communications, food, and survival, on an untried mission, to an unknown celestial body, and then return it safely to earth, reentering the atmosphere at speeds of over 25,000 miles per hour, causing heat about half that of the temperature of the sun. Alternatively, this could be an opportunity for some command chair antics. But a proper rocket is probably your best bet. You will need to upgrade your astronaut complex to level five to plant a flag on the Moon and complete the first crewed landing contract.
 	requirementsPrettyText = Complete contracts X and Y
-	objectivesPrettyText = Send crew to flyby, orbit, and land on the Moon.
+	objectivesPrettyText = Send crew to flyby, orbit, and land on the Moon. 
 	nominalDurationYears = 12
 	baseFunding = 15720000
 	fundingCurve = MildMidFundingCurve
@@ -871,12 +871,12 @@ RP0_PROGRAM
 		{
 			name = first_MoonFlybyCrewed
 		}
-
+		
 		COMPLETE_CONTRACT
 		{
 			name = FirstCrewedLunarOrbit
 		}
-
+		
 		ANY
 		{
 			complete_contract = first_MoonLandingCrewed
@@ -889,13 +889,13 @@ RP0_PROGRAM
 			minCount = 2
 		}
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 5250
 		Fast = 10500
 	}
-
+	
 	OPTIONALS
 	{
 		CrewedLunarOrbitRepeat = true
@@ -930,7 +930,7 @@ disabled_RP0_PROGRAM
 		complete_contract = first_ISScrew
 		complete_contract = second_ISScrew
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 5000
@@ -941,10 +941,10 @@ disabled_RP0_PROGRAM
 RP0_PROGRAM
 {
 	name = MarsSurfaceExp
-	title = Mars Surface Exploration
-	description = Send probes to Mars to survey its atmosphere, land on the surface, and even drive around with a rover. The thin atmosphere of Mars is enough to produce quite a bit of reentry heating, but it's not thick enough to safely land with only parachutes.
+	title = Mars Surface Exploration 
+	description = Send probes to Mars to survey its atmosphere, land on the surface, and even drive around with a rover. The thin atmosphere of Mars is enough to produce quite a bit of reentry heating, but it's not thick enough to safely land with only parachutes. 
 	requirementsPrettyText = Complete contracts X and Y
-	objectivesPrettyText = Complete the program by sending a rover to Mars.
+	objectivesPrettyText = Complete the program by sending a rover to Mars. 
 	nominalDurationYears = 8
 	baseFunding = 4800000
 	repDeltaOnCompletePerYearEarly = 620
@@ -962,13 +962,13 @@ RP0_PROGRAM
 		complete_contract = landingMars
 		complete_contract = roverMars
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 2500
 		Fast = 5000
 	}
-
+	
 	OPTIONALS
 	{
 		flybyDeimos = true
@@ -981,13 +981,13 @@ RP0_PROGRAM
 		landingMarsRepeatable = true
 		roverMarsRepeatable = true
 	}
-
+	
 }
 
 RP0_PROGRAM
 {
 	name = VenusSurfaceExp
-	title = Venus Surface Exploration
+	title = Venus Surface Exploration 
 	description = Send probes to Venus to see what the surface and atmosphere are really like. The dense clouds hide the surface from view, while the corrosive atmosphere and high heat present challenges for anything trying to descend to the surface. Keeping a probe operational for any length of time presents significant challenges. Even with heat-resistant materials, nothing seems able to survive for more than a few hours.
 	requirementsPrettyText = Complete contracts X and Y
 	objectivesPrettyText = Land a probe on Venus.
@@ -1007,13 +1007,13 @@ RP0_PROGRAM
 	{
 		complete_contract = landingVenus
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 1800
 		Fast = 3600
 	}
-
+	
 	OPTIONALS
 	{
 		probeVenus = true
@@ -1050,7 +1050,7 @@ RP0_PROGRAM
 			complete_contract = flybyVesta
 		}
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 2650
@@ -1064,7 +1064,7 @@ RP0_PROGRAM
 	title = Mercury Exploration
 	description = Mercury is the least explored of the inner planets, due to the difficulty of orbiting it. Send some probes there to find out more about it. Current data suggests that Mercury is tidally locked with the Sun. How will this affect its surface? Or did we just flyby it at remarkably synchronized times? Either way, sending probes to orbit and land on Mercury will provide fascinating data on the closest planet to the Sun.
 	requirementsPrettyText = Do this and that
-	objectivesPrettyText = Orbit and land on Mercury.
+	objectivesPrettyText = Orbit and land on Mercury. 
 	nominalDurationYears = 8
 	baseFunding = 4800000
 	repDeltaOnCompletePerYearEarly = 415
@@ -1082,13 +1082,13 @@ RP0_PROGRAM
 		complete_contract = orbitMercury
 		complete_contract = landingMercury
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 3200
 		Fast = 6400
 	}
-
+	
 	OPTIONALS
 	{
 		orbitMercury_Rep = true
@@ -1121,13 +1121,13 @@ RP0_PROGRAM
 		complete_contract = orbitCeres
 		complete_contract = orbitVesta
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 5600
 		Fast = 11200
 	}
-
+	
 	OPTIONALS
 	{
 		orbitCeres_Rep = true
@@ -1141,7 +1141,7 @@ RP0_PROGRAM
 {
 	name = JupiterObservation
 	title = Jupiter Observation
-	description = Jupiter presents many opportunities for exploration, but also many challenges: it requires almost the same amount of energy for a spacecraft to reach Jupiter from Earth's orbit as it does to lift it into orbit in the first place. Gravity assists can be used to save delta-v at the cost of flight duration. Once there, a rich and diverse system awaits any explorer. Along with the largest planet in the Solar System, the Jovian system is also home to the largest moon, Ganymede, a planetary-mass moon. This program will send uncrewed scientific probes to Jupiter and its moons.<br><br>Historically, Jupiter is the most-visited outer planet, with 9 missions having completed flybys or entered orbits, most notably by the Voyager missions in 1979 on their flybys towards the outer Solar System, and by the Juno orbiter whose mission continues today. Most recently, ESA's JUICE mission departed in 2023 enroute to the Galilean moons.
+	description = Jupiter presents many opportunities for exploration, but also many challenges: it requires almost the same amount of energy for a spacecraft to reach Jupiter from Earth's orbit as it does to lift it into orbit in the first place. Gravity assists can be used to save delta-v at the cost of flight duration. Once there, a rich and diverse system awaits any explorer. Along with the largest planet in the Solar System, the Jovian system is also home to the largest moon, Ganymede, a planetary-mass moon. This program will send uncrewed scientific probes to Jupiter and its moons.<br><br>Historically, Jupiter is the most-visited outer planet, with 9 missions having completed flybys or entered orbits, most notably by the Voyager missions in 1979 on their flybys towards the outer Solar System, and by the Juno orbiter whose mission continues today. Most recently, ESA's JUICE mission departed in 2023 enroute to the Galilean moons. 
 	requirementsPrettyText = Complete contracts X and Y
 	objectivesPrettyText = Orbit Jupiter and flyby at least two Galilean moons.
 	nominalDurationYears = 8
@@ -1171,13 +1171,13 @@ RP0_PROGRAM
 			}
 		}
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 2650
 		Fast = 5300
 	}
-
+	
 	OPTIONALS
 	{
 		orbitJupiter_Rep = true
@@ -1202,7 +1202,7 @@ disabled_RP0_PROGRAM
 	{
 		complete_program = JupiterObservation
 	}
-
+	
 	OBJECTIVES
 	{
 		ATLEAST
@@ -1214,13 +1214,13 @@ disabled_RP0_PROGRAM
 			complete_contract = landingGanymede
 		}
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 9600
 		Fast = 19200
 	}
-
+	
 	OPTIONALS
 	{
 		orbitJupiter_Rep = true
@@ -1231,7 +1231,7 @@ RP0_PROGRAM
 {
 	name = SaturnObservation
 	title = Saturn Observation
-	description = Known for its photogenic rings, Saturn has long been a subject of observation and exploration. Visible from Earth with little more than a set of binoculars, Saturn's rings have intrigued observers for centuries. Further, with the highest number of moons in the entire Solar System, and more discovered with each additional mission, the Saturn system is a destination with extensive exploration opportunities. Titan, the largest moon of Saturn, may have an atmosphere conducive to life, while Enceladus is thought to contain liquid water below its icy exterior. Explore the Saturn system with uncrewed probes, analyzing the atmospheres of Saturn and Titan, and take a closer look at the larger moons of the system.<br><br>Historical missions to Saturn include flybys from Pioneer 11 and both Voyagers, while the Cassini orbiter mission operated from 2004 to 2017.
+	description = Known for its photogenic rings, Saturn has long been a subject of observation and exploration. Visible from Earth with little more than a set of binoculars, Saturn's rings have intrigued observers for centuries. Further, with the highest number of moons in the entire Solar System, and more discovered with each additional mission, the Saturn system is a destination with extensive exploration opportunities. Titan, the largest moon of Saturn, may have an atmosphere conducive to life, while Enceladus is thought to contain liquid water below its icy exterior. Explore the Saturn system with uncrewed probes, analyzing the atmospheres of Saturn and Titan, and take a closer look at the larger moons of the system.<br><br>Historical missions to Saturn include flybys from Pioneer 11 and both Voyagers, while the Cassini orbiter mission operated from 2004 to 2017. 
 
 	requirementsPrettyText = Complete contracts X and Y
 	objectivesPrettyText = Send an orbiter to Saturn, an atmospheric probe to Titan or Saturn, and flyby two more moons in addition to Titan.
@@ -1270,13 +1270,13 @@ RP0_PROGRAM
 			}
 		}
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 3650
 		Fast = 7300
 	}
-
+	
 	OPTIONALS
 	{
 		orbitSaturn_Rep = true
@@ -1316,13 +1316,13 @@ disabled_RP0_PROGRAM
 			complete_contract = landingRhea
 		}
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 14400
 		Fast = 28800
 	}
-
+	
 	OPTIONALS
 	{
 		orbitSaturn_Rep = true
@@ -1348,7 +1348,7 @@ RP0_PROGRAM
 	{
 		complete_program = EarlyInnerPlanetProbes
 	}
-
+	
 	OBJECTIVES
 	{
 		ATLEAST
@@ -1361,13 +1361,13 @@ RP0_PROGRAM
 			complete_contract = flybyPluto
 		}
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 3600
 		Fast = 7200
 	}
-
+	
 	OPTIONALS
 	{
 		flybyCharon = true
@@ -1377,7 +1377,7 @@ RP0_PROGRAM
 RP0_PROGRAM
 {
 	name = OuterGasGiantSurvey
-	title = Outer Gas Giant Survey
+	title = Outer Gas Giant Survey 
 	description = Pictures can help expand our knowledge of the outer Solar System, but scientific instruments and dwell times much longer than a hasty flyby are necessary to increase our understanding of these distant neighbors. Send orbiters to the two furthest gas giants and probe their atmospheres. While in the furthest reaches of our system, explore the moons of these giants as well. An upgraded Tracking Station and higher level comm tech will be necessary in order to receive scientific data over such great distances.
 	requirementsPrettyText = Complete contracts X and Y
 	objectivesPrettyText = Do this and that
@@ -1392,10 +1392,10 @@ RP0_PROGRAM
 	{
 		complete_program = OuterPlanetFlyby
 	}
-
+	
 	OBJECTIVES
 	{
-		All
+		All 
 		{
 			complete_contract = orbitUranus
 			Any
@@ -1415,13 +1415,13 @@ RP0_PROGRAM
 			}
 		}
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 7200
 		Fast = 14400
 	}
-
+	
 	OPTIONALS
 	{
 		orbitNeptune_Rep = true
@@ -1433,7 +1433,7 @@ RP0_PROGRAM
 RP0_PROGRAM
 {
 	name = PlutoLandings
-	title = Plutonian Landings
+	title = Plutonian Landings 
 	description = The only known double planetary system in the Solar System, Pluto and Charon have been tidally locked in orbit of each other in the darkest, coldest reaches of our system for eons. It is now time for you to land on them, quite possibly within a century of their discovery. Very little is known about these distant, icy worlds. Historically, even our most advanced probes have returned relatively little data compared to what we know about our closer neighbors. Explore the furthest reaches of the Solar System and land on this intriguing pair of dwarf planets.
 	requirementsPrettyText = Complete contracts X and Y
 	objectivesPrettyText = Land on Pluto and Charon.
@@ -1455,13 +1455,13 @@ RP0_PROGRAM
 		complete_contract = landingPluto
 		complete_contract = landingCharon
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 16800
 		Fast = 33600
 	}
-
+	
 	OPTIONALS
 	{
 		roverPluto = true
@@ -1499,7 +1499,7 @@ disabled_RP0_PROGRAM
 	{
 		complete_contract = TODO
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 13350
@@ -1531,7 +1531,7 @@ disabled_RP0_PROGRAM
 	{
 		complete_contract = TODO
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 28000
@@ -1563,7 +1563,7 @@ disabled_RP0_PROGRAM
 	{
 		complete_contract = TODO
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 10000
@@ -1595,7 +1595,7 @@ disabled_RP0_PROGRAM
 	{
 		complete_contract = TODO
 	}
-
+	
 	CONFIDENCECOSTS
 	{
 		Normal = 40000

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -44,7 +44,7 @@ RP0_PROGRAM
 			name = XPlanesKarman
 		}
 	}
-	
+
 	OPTIONALS
 	{
 		XPlanesSupersonicOptionalLow = true
@@ -55,7 +55,7 @@ RP0_PROGRAM
 		XPlanesSuborbital = true
 		XPlanesHypersonicOptional = true
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 350
@@ -83,13 +83,13 @@ RP0_PROGRAM
 		complete_contract = DownrangeEarly
 		complete_contract = Downrange
 	}
-	
+
 	OPTIONALS
 	{
 		DownrangeSoundingIntermediate = true
 		DistanceSoundingDifficult = true
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 150
@@ -116,23 +116,23 @@ RP0_PROGRAM
 		{
 			name = KarmanLine
 		}
-		
+
 		COMPLETE_CONTRACT
 		{
 			name = SoundingRocketFilm
 		}
-		
+
 		COMPLETE_CONTRACT
 		{
 			name = SoundingRocketBio
 		}
-		
+
 		COMPLETE_CONTRACT
 		{
 			name = SoundingRocketAdvancedBio
 		}
 	}
-	
+
 	OPTIONALS
 	{
 		SoundingDifficult = true
@@ -141,7 +141,7 @@ RP0_PROGRAM
 		SoundingRocketBioOptional = true
 		SoundingRocketAdvancedBioOptional = true
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 150
@@ -237,13 +237,13 @@ RP0_PROGRAM
 	{
 		EarlySatellites = true
 	}
-	
+
 	OPTIONALS
 	{
 		Downrange6000-Heavy = true
 		Downrange7500-Heavy = true
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 600
@@ -283,7 +283,7 @@ RP0_PROGRAM
 		complete_contract = FirstMolniyaSat
 		complete_contract = FirstTundraSat
 	}
-	
+
 	OPTIONALS
 	{
 		ComTestSat = true
@@ -300,7 +300,7 @@ RP0_PROGRAM
 {
 	name = EarthObservationScience1
 	title = Early Earth Observation Satellites
-	description = Now that you have proven the ability to send satellites into orbit, the next step is to send them into more useful orbits with more beneficial payloads. This program will focus on satellites for observing the Earth and the space environment around it. This will advance scientific knowledge of not just physical processes within our atmosphere, but also those in space, all of which influence our lives here on Earth. 
+	description = Now that you have proven the ability to send satellites into orbit, the next step is to send them into more useful orbits with more beneficial payloads. This program will focus on satellites for observing the Earth and the space environment around it. This will advance scientific knowledge of not just physical processes within our atmosphere, but also those in space, all of which influence our lives here on Earth.
 	requirementsPrettyText = Complete Early Satellites program
 	objectivesPrettyText = Launch satellites to photograph the Earth, analyze weather, measure solar wind and cosmic rays, and determine the extent of the Magnetosphere.
 	nominalDurationYears = 4
@@ -328,7 +328,7 @@ RP0_PROGRAM
 		complete_contract = first_OrbitRecover
 		complete_contract = EOSCorona
 	}
-	
+
 	OPTIONALS
 	{
 		EOSGrav1 = true
@@ -348,9 +348,9 @@ RP0_PROGRAM
 {
 	name = CommercialApplications1
 	title = Early Commercial Applications
-	description = Although the earliest satellites were launched through government programs, commercial uses had been envisioned for a long time. Through this program, you will launch the earliest iterations of commercial-use satellites. With wildly varying needs, each satellite is dedicated to a specific requirement, typically with far more focused requirements than the earlier, broader scientific satellites. 
+	description = Although the earliest satellites were launched through government programs, commercial uses had been envisioned for a long time. Through this program, you will launch the earliest iterations of commercial-use satellites. With wildly varying needs, each satellite is dedicated to a specific requirement, typically with far more focused requirements than the earlier, broader scientific satellites.
 	requirementsPrettyText = Complete Early Satellites program
-	objectivesPrettyText = Launch the first commercial-use satellites and build a satellite communication network. 
+	objectivesPrettyText = Launch the first commercial-use satellites and build a satellite communication network.
 	nominalDurationYears = 4
 	baseFunding = 560000
 	fundingCurve = MildRampupCurve
@@ -382,7 +382,7 @@ RP0_PROGRAM
 			complete_contract = EarlyComNetwork4-CA
 		}
 	}
-	
+
 	OPTIONALS
 	{
 		EarlyComSat-CA = true
@@ -429,7 +429,7 @@ RP0_PROGRAM
 			complete_contract = EarlyComNetwork4
 		}
 	}
-	
+
 	OPTIONALS
 	{
 		ComTestSat = true
@@ -446,7 +446,7 @@ RP0_PROGRAM
 RP0_PROGRAM
 {
 	name = GEOCommNetwork
-	title = Geostationary Communication Network 
+	title = Geostationary Communication Network
 	description = With geostationary orbits, satellites can be placed at specific spots over the equator where they will stay. This allows communications satellites to be put exactly where they will have the greatest benefit. This program tasks you with creating a 4-satellite Geostationary Network for communication. Each satellite will require 315 units of ComSatPayload.
 	requirementsPrettyText = Complete the Targeted Satellites Program
 	objectivesPrettyText = Complete the Geostationary Communications Network.
@@ -470,12 +470,12 @@ RP0_PROGRAM
 	{
 		complete_contract = GeoComSatNetwork
 	}
-	
+
 	OPTIONALS
 	{
 		GEORepeatComSats = true
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 450
@@ -496,7 +496,7 @@ RP0_PROGRAM
 	slots = 2
 
 	REQUIREMENTS
-	{	
+	{
 		ANY
 		{
 			complete_contract = FirstScienceSat
@@ -520,13 +520,13 @@ RP0_PROGRAM
 		complete_contract = LunarImpactor
 		complete_contract = LunarOrbiter
 	}
-	
+
 	OPTIONALS
 	{
 		LunarImpactorOptional = true
 		LunarOrbiterOptional = true
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 550
@@ -538,7 +538,7 @@ RP0_PROGRAM
 {
 	name = UncrewedLunarSurface
 	title = Uncrewed Lunar Surface Exploration
-	description = Landing uncrewed probes on the Moon is the next step in exploring the Solar System. Successfully landing on the Moon is a difficult problem to solve. You will need to develop even more capable launch vehicles to be able to launch a large enough payload. These uncrewed landings will give you the data you need to plan for your crewed landings to follow. You will need to research deeply-throttleable engines from the Early Landing node (recommended) or figure out how to perform a landing with RCS. 
+	description = Landing uncrewed probes on the Moon is the next step in exploring the Solar System. Successfully landing on the Moon is a difficult problem to solve. You will need to develop even more capable launch vehicles to be able to launch a large enough payload. These uncrewed landings will give you the data you need to plan for your crewed landings to follow. You will need to research deeply-throttleable engines from the Early Landing node (recommended) or figure out how to perform a landing with RCS.
 	requirementsPrettyText = Complete the Early Lunar Probes program
 	objectivesPrettyText = Land probes on the Moon.
 	nominalDurationYears = 5
@@ -560,7 +560,7 @@ RP0_PROGRAM
 		complete_contract = MoonOrbiter
 		complete_contract = MoonLandingFarSide
 	}
-	
+
 	OPTIONALS
 	{
 		MoonLandingOptional = true
@@ -569,7 +569,7 @@ RP0_PROGRAM
 		MoonRover = true
 		MoonLandingReturn = true
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 900
@@ -593,7 +593,7 @@ RP0_PROGRAM
 	repPenaltyPerYearLate = 895
 	repToConfidence = 3
 	slots = 3
-	
+
 	REQUIREMENTS
 	{
 		ANY
@@ -617,7 +617,7 @@ RP0_PROGRAM
 		complete_contract = Rendezvous
 		complete_contract = first_Docking
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 2400
@@ -651,7 +651,7 @@ RP0_PROGRAM
 	repPenaltyPerYearLate = 315
 	repToConfidence = 3
 	slots = 3
-	
+
 	REQUIREMENTS
 	{
 		ANY
@@ -673,7 +673,7 @@ RP0_PROGRAM
 		complete_contract = first_OrbitCrewed
 		complete_contract = CollectCrewedScienceBasic
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 800
@@ -707,7 +707,7 @@ RP0_PROGRAM
 	repPenaltyPerYearLate = 575
 	repToConfidence = 3
 	slots = 3
-	
+
 	REQUIREMENTS
 	{
 		complete_program = CrewedOrbitEarly
@@ -724,7 +724,7 @@ RP0_PROGRAM
 		complete_contract = Rendezvous
 		complete_contract = first_Docking
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 1450
@@ -777,7 +777,7 @@ RP0_PROGRAM
 		OrbitalPlane3 = true
 		CrewedSpaceplaneSuborbital = true
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 2500
@@ -788,7 +788,7 @@ RP0_PROGRAM
 RP0_PROGRAM
 {
 	name = EarlyInnerPlanetProbes
-	title = Early Inner Planet Probes 
+	title = Early Inner Planet Probes
 	description = This program tasks you with exploring Venus and Mars. Though these may be Earth's closest neighbors, the distance between us and them still averages in the hundreds of millions of kilometers. Staying in contact with these probes will require advances in communication technology. Maintaining functionality and power over such great distances and long times will present new challenges in spacecraft design.
 	requirementsPrettyText = Complete contracts X and Y
 	objectivesPrettyText = Orbit Venus and Mars.
@@ -816,13 +816,13 @@ RP0_PROGRAM
 		complete_contract = orbitMars
 		complete_contract = orbitVenus
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 1300
 		Fast = 2600
 	}
-	
+
 	OPTIONALS
 	{
 		MarsOrbitRepeatable = true
@@ -837,7 +837,7 @@ RP0_PROGRAM
 	title = Crewed Lunar Exploration
 	description = You are tasked with sending to the Moon, 240,000 miles away from the control station in Houston, a giant rocket more than 300 feet tall, made of new metal alloys, some of which have not yet been invented, capable of standing heat and stresses several times more than have ever been experienced, fitted together with a precision better than the finest watch, carrying all the equipment needed for propulsion, guidance, control, communications, food, and survival, on an untried mission, to an unknown celestial body, and then return it safely to earth, reentering the atmosphere at speeds of over 25,000 miles per hour, causing heat about half that of the temperature of the sun. Alternatively, this could be an opportunity for some command chair antics. But a proper rocket is probably your best bet. You will need to upgrade your astronaut complex to level five to plant a flag on the Moon and complete the first crewed landing contract.
 	requirementsPrettyText = Complete contracts X and Y
-	objectivesPrettyText = Send crew to flyby, orbit, and land on the Moon. 
+	objectivesPrettyText = Send crew to flyby, orbit, and land on the Moon.
 	nominalDurationYears = 12
 	baseFunding = 15720000
 	fundingCurve = MildMidFundingCurve
@@ -871,12 +871,12 @@ RP0_PROGRAM
 		{
 			name = first_MoonFlybyCrewed
 		}
-		
+
 		COMPLETE_CONTRACT
 		{
 			name = FirstCrewedLunarOrbit
 		}
-		
+
 		ANY
 		{
 			complete_contract = first_MoonLandingCrewed
@@ -889,13 +889,13 @@ RP0_PROGRAM
 			minCount = 2
 		}
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 5250
 		Fast = 10500
 	}
-	
+
 	OPTIONALS
 	{
 		CrewedLunarOrbitRepeat = true
@@ -930,7 +930,7 @@ disabled_RP0_PROGRAM
 		complete_contract = first_ISScrew
 		complete_contract = second_ISScrew
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 5000
@@ -941,10 +941,10 @@ disabled_RP0_PROGRAM
 RP0_PROGRAM
 {
 	name = MarsSurfaceExp
-	title = Mars Surface Exploration 
-	description = Send probes to Mars to survey its atmosphere, land on the surface, and even drive around with a rover. The thin atmosphere of Mars is enough to produce quite a bit of reentry heating, but it's not thick enough to safely land with only parachutes. 
+	title = Mars Surface Exploration
+	description = Send probes to Mars to survey its atmosphere, land on the surface, and even drive around with a rover. The thin atmosphere of Mars is enough to produce quite a bit of reentry heating, but it's not thick enough to safely land with only parachutes.
 	requirementsPrettyText = Complete contracts X and Y
-	objectivesPrettyText = Complete the program by sending a rover to Mars. 
+	objectivesPrettyText = Complete the program by sending a rover to Mars.
 	nominalDurationYears = 8
 	baseFunding = 4800000
 	repDeltaOnCompletePerYearEarly = 620
@@ -962,13 +962,13 @@ RP0_PROGRAM
 		complete_contract = landingMars
 		complete_contract = roverMars
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 2500
 		Fast = 5000
 	}
-	
+
 	OPTIONALS
 	{
 		flybyDeimos = true
@@ -978,14 +978,16 @@ RP0_PROGRAM
 		probeMars = true
 		samplesPhobos = true
 		MarsOrbitRepeatable = true
+		landingMarsRepeatable = true
+		roverMarsRepeatable = true
 	}
-	
+
 }
 
 RP0_PROGRAM
 {
 	name = VenusSurfaceExp
-	title = Venus Surface Exploration 
+	title = Venus Surface Exploration
 	description = Send probes to Venus to see what the surface and atmosphere are really like. The dense clouds hide the surface from view, while the corrosive atmosphere and high heat present challenges for anything trying to descend to the surface. Keeping a probe operational for any length of time presents significant challenges. Even with heat-resistant materials, nothing seems able to survive for more than a few hours.
 	requirementsPrettyText = Complete contracts X and Y
 	objectivesPrettyText = Land a probe on Venus.
@@ -1004,19 +1006,19 @@ RP0_PROGRAM
 	OBJECTIVES
 	{
 		complete_contract = landingVenus
-		minCount = 3
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 1800
 		Fast = 3600
 	}
-	
+
 	OPTIONALS
 	{
 		probeVenus = true
 		VenusOrbitRepeatable = true
+		landingVenusRepeatable = true
 	}
 }
 
@@ -1048,7 +1050,7 @@ RP0_PROGRAM
 			complete_contract = flybyVesta
 		}
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 2650
@@ -1062,7 +1064,7 @@ RP0_PROGRAM
 	title = Mercury Exploration
 	description = Mercury is the least explored of the inner planets, due to the difficulty of orbiting it. Send some probes there to find out more about it. Current data suggests that Mercury is tidally locked with the Sun. How will this affect its surface? Or did we just flyby it at remarkably synchronized times? Either way, sending probes to orbit and land on Mercury will provide fascinating data on the closest planet to the Sun.
 	requirementsPrettyText = Do this and that
-	objectivesPrettyText = Orbit and land on Mercury. 
+	objectivesPrettyText = Orbit and land on Mercury.
 	nominalDurationYears = 8
 	baseFunding = 4800000
 	repDeltaOnCompletePerYearEarly = 415
@@ -1080,16 +1082,17 @@ RP0_PROGRAM
 		complete_contract = orbitMercury
 		complete_contract = landingMercury
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 3200
 		Fast = 6400
 	}
-	
+
 	OPTIONALS
 	{
 		orbitMercury_Rep = true
+		landingMercuryRepeatable = true
 		roverMercury = true
 	}
 }
@@ -1118,13 +1121,13 @@ RP0_PROGRAM
 		complete_contract = orbitCeres
 		complete_contract = orbitVesta
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 5600
 		Fast = 11200
 	}
-	
+
 	OPTIONALS
 	{
 		orbitCeres_Rep = true
@@ -1138,7 +1141,7 @@ RP0_PROGRAM
 {
 	name = JupiterObservation
 	title = Jupiter Observation
-	description = Jupiter presents many opportunities for exploration, but also many challenges: it requires almost the same amount of energy for a spacecraft to reach Jupiter from Earth's orbit as it does to lift it into orbit in the first place. Gravity assists can be used to save delta-v at the cost of flight duration. Once there, a rich and diverse system awaits any explorer. Along with the largest planet in the Solar System, the Jovian system is also home to the largest moon, Ganymede, a planetary-mass moon. This program will send uncrewed scientific probes to Jupiter and its moons.<br><br>Historically, Jupiter is the most-visited outer planet, with 9 missions having completed flybys or entered orbits, most notably by the Voyager missions in 1979 on their flybys towards the outer Solar System, and by the Juno orbiter whose mission continues today. Most recently, ESA's JUICE mission departed in 2023 enroute to the Galilean moons. 
+	description = Jupiter presents many opportunities for exploration, but also many challenges: it requires almost the same amount of energy for a spacecraft to reach Jupiter from Earth's orbit as it does to lift it into orbit in the first place. Gravity assists can be used to save delta-v at the cost of flight duration. Once there, a rich and diverse system awaits any explorer. Along with the largest planet in the Solar System, the Jovian system is also home to the largest moon, Ganymede, a planetary-mass moon. This program will send uncrewed scientific probes to Jupiter and its moons.<br><br>Historically, Jupiter is the most-visited outer planet, with 9 missions having completed flybys or entered orbits, most notably by the Voyager missions in 1979 on their flybys towards the outer Solar System, and by the Juno orbiter whose mission continues today. Most recently, ESA's JUICE mission departed in 2023 enroute to the Galilean moons.
 	requirementsPrettyText = Complete contracts X and Y
 	objectivesPrettyText = Orbit Jupiter and flyby at least two Galilean moons.
 	nominalDurationYears = 8
@@ -1168,13 +1171,13 @@ RP0_PROGRAM
 			}
 		}
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 2650
 		Fast = 5300
 	}
-	
+
 	OPTIONALS
 	{
 		orbitJupiter_Rep = true
@@ -1199,7 +1202,7 @@ disabled_RP0_PROGRAM
 	{
 		complete_program = JupiterObservation
 	}
-	
+
 	OBJECTIVES
 	{
 		ATLEAST
@@ -1211,13 +1214,13 @@ disabled_RP0_PROGRAM
 			complete_contract = landingGanymede
 		}
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 9600
 		Fast = 19200
 	}
-	
+
 	OPTIONALS
 	{
 		orbitJupiter_Rep = true
@@ -1228,7 +1231,7 @@ RP0_PROGRAM
 {
 	name = SaturnObservation
 	title = Saturn Observation
-	description = Known for its photogenic rings, Saturn has long been a subject of observation and exploration. Visible from Earth with little more than a set of binoculars, Saturn's rings have intrigued observers for centuries. Further, with the highest number of moons in the entire Solar System, and more discovered with each additional mission, the Saturn system is a destination with extensive exploration opportunities. Titan, the largest moon of Saturn, may have an atmosphere conducive to life, while Enceladus is thought to contain liquid water below its icy exterior. Explore the Saturn system with uncrewed probes, analyzing the atmospheres of Saturn and Titan, and take a closer look at the larger moons of the system.<br><br>Historical missions to Saturn include flybys from Pioneer 11 and both Voyagers, while the Cassini orbiter mission operated from 2004 to 2017. 
+	description = Known for its photogenic rings, Saturn has long been a subject of observation and exploration. Visible from Earth with little more than a set of binoculars, Saturn's rings have intrigued observers for centuries. Further, with the highest number of moons in the entire Solar System, and more discovered with each additional mission, the Saturn system is a destination with extensive exploration opportunities. Titan, the largest moon of Saturn, may have an atmosphere conducive to life, while Enceladus is thought to contain liquid water below its icy exterior. Explore the Saturn system with uncrewed probes, analyzing the atmospheres of Saturn and Titan, and take a closer look at the larger moons of the system.<br><br>Historical missions to Saturn include flybys from Pioneer 11 and both Voyagers, while the Cassini orbiter mission operated from 2004 to 2017.
 
 	requirementsPrettyText = Complete contracts X and Y
 	objectivesPrettyText = Send an orbiter to Saturn, an atmospheric probe to Titan or Saturn, and flyby two more moons in addition to Titan.
@@ -1267,13 +1270,13 @@ RP0_PROGRAM
 			}
 		}
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 3650
 		Fast = 7300
 	}
-	
+
 	OPTIONALS
 	{
 		orbitSaturn_Rep = true
@@ -1313,16 +1316,17 @@ disabled_RP0_PROGRAM
 			complete_contract = landingRhea
 		}
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 14400
 		Fast = 28800
 	}
-	
+
 	OPTIONALS
 	{
 		orbitSaturn_Rep = true
+		roverTitan = true
 	}
 }
 
@@ -1344,7 +1348,7 @@ RP0_PROGRAM
 	{
 		complete_program = EarlyInnerPlanetProbes
 	}
-	
+
 	OBJECTIVES
 	{
 		ATLEAST
@@ -1357,13 +1361,13 @@ RP0_PROGRAM
 			complete_contract = flybyPluto
 		}
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 3600
 		Fast = 7200
 	}
-	
+
 	OPTIONALS
 	{
 		flybyCharon = true
@@ -1373,7 +1377,7 @@ RP0_PROGRAM
 RP0_PROGRAM
 {
 	name = OuterGasGiantSurvey
-	title = Outer Gas Giant Survey 
+	title = Outer Gas Giant Survey
 	description = Pictures can help expand our knowledge of the outer Solar System, but scientific instruments and dwell times much longer than a hasty flyby are necessary to increase our understanding of these distant neighbors. Send orbiters to the two furthest gas giants and probe their atmospheres. While in the furthest reaches of our system, explore the moons of these giants as well. An upgraded Tracking Station and higher level comm tech will be necessary in order to receive scientific data over such great distances.
 	requirementsPrettyText = Complete contracts X and Y
 	objectivesPrettyText = Do this and that
@@ -1388,10 +1392,10 @@ RP0_PROGRAM
 	{
 		complete_program = OuterPlanetFlyby
 	}
-	
+
 	OBJECTIVES
 	{
-		All 
+		All
 		{
 			complete_contract = orbitUranus
 			Any
@@ -1411,13 +1415,13 @@ RP0_PROGRAM
 			}
 		}
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 7200
 		Fast = 14400
 	}
-	
+
 	OPTIONALS
 	{
 		orbitNeptune_Rep = true
@@ -1429,7 +1433,7 @@ RP0_PROGRAM
 RP0_PROGRAM
 {
 	name = PlutoLandings
-	title = Plutonian Landings 
+	title = Plutonian Landings
 	description = The only known double planetary system in the Solar System, Pluto and Charon have been tidally locked in orbit of each other in the darkest, coldest reaches of our system for eons. It is now time for you to land on them, quite possibly within a century of their discovery. Very little is known about these distant, icy worlds. Historically, even our most advanced probes have returned relatively little data compared to what we know about our closer neighbors. Explore the furthest reaches of the Solar System and land on this intriguing pair of dwarf planets.
 	requirementsPrettyText = Complete contracts X and Y
 	objectivesPrettyText = Land on Pluto and Charon.
@@ -1451,17 +1455,19 @@ RP0_PROGRAM
 		complete_contract = landingPluto
 		complete_contract = landingCharon
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 16800
 		Fast = 33600
 	}
-	
+
 	OPTIONALS
 	{
 		roverPluto = true
 		roverCharon = true
+		landingPlutoRepeat = true
+		landingCharonRepeat = true
 	}
 }
 
@@ -1493,7 +1499,7 @@ disabled_RP0_PROGRAM
 	{
 		complete_contract = TODO
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 13350
@@ -1525,7 +1531,7 @@ disabled_RP0_PROGRAM
 	{
 		complete_contract = TODO
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 28000
@@ -1557,7 +1563,7 @@ disabled_RP0_PROGRAM
 	{
 		complete_contract = TODO
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 10000
@@ -1589,7 +1595,7 @@ disabled_RP0_PROGRAM
 	{
 		complete_contract = TODO
 	}
-	
+
 	CONFIDENCECOSTS
 	{
 		Normal = 40000

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -497,7 +497,7 @@ RP0_PROGRAM
 
 	REQUIREMENTS
 	{
-		ANY
+	ANY
 		{
 			complete_contract = FirstScienceSat
 			complete_contract = FirstScienceSat-Heavy
@@ -981,7 +981,6 @@ RP0_PROGRAM
 		landingMarsRepeatable = true
 		roverMarsRepeatable = true
 	}
-
 }
 
 RP0_PROGRAM

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -497,7 +497,7 @@ RP0_PROGRAM
 
 	REQUIREMENTS
 	{
-	ANY
+		ANY
 		{
 			complete_contract = FirstScienceSat
 			complete_contract = FirstScienceSat-Heavy
@@ -981,6 +981,7 @@ RP0_PROGRAM
 		landingMarsRepeatable = true
 		roverMarsRepeatable = true
 	}
+
 }
 
 RP0_PROGRAM


### PR DESCRIPTION
Based on issue #2288 

- Split Venus landing into Capstone and optional repeatable, added optional to program definition
- Split Mars Landing and Mars Rover into required and optional repeatable, added optionals to program definition
- Split Mercury, Pluto, and Charon Landing into required and optional repeatables, added optionals to program definitions
- Crewed Targeted Moon Landing looks to be intentional.  The program requires 2 completions, and the contract is completable twice.
- Titan Rover was checking for SaturnObservation as the active program, but wasn't listed in the program.  It doesn't make sense there, so changing the check and optional listing to be SaturnMoonLandings.