### PR TITLE
Fix descriptive text in the biological satellite contract parameters.

### DIFF
--- a/GameData/RP-1/Contracts/Early Satellites (Heavy)/FirstBioSat-Heavy.cfg
+++ b/GameData/RP-1/Contracts/Early Satellites (Heavy)/FirstBioSat-Heavy.cfg
@@ -102,7 +102,7 @@ CONTRACT_TYPE
 		{
 			name = OrbitSequence
 			type = Sequence
-			title = Survive in orbit for a day and transmit science
+			title = Survive in orbit for a day
 
 			PARAMETER
 			{


### PR DESCRIPTION
Transmitting science isn't a contract requirement, so I removed the text for that.  Also, the contract description is a direct copy of the science satellite contract, so it needs editing.