### PR TITLE
Fix objectivesPrettyText of Suborbital Rocket Development

### DIFF
--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -68,7 +68,7 @@ RP0_PROGRAM
 	name = SuborbRocketDev
 	title = Early Rocket Development
 	description = The first step in developing orbit capable rockets. This programs requires progressively developing suborbital rockets with increasing capabilities.
-	objectivesPrettyText = Complete Karman Line, Reach a Suborbital Trajectory & Return (uncrewed), and Downrange Milestone (4500 km) contracts.
+	objectivesPrettyText = Complete Karman Line, Reach a Suborbital Trajectory & Return (uncrewed), and Downrange Milestone (5000 km) contracts.
 	nominalDurationYears = 6
 	baseFunding = 210000
 	fundingCurve = SlowRampupCurve


### PR DESCRIPTION
`objectivesPrettyText` for Suborbital Rocket Development incorrectly reads 4500 km instead of 5000 km.