### PR TITLE
Improve information shown in part tooltips and fix training course names

### DIFF
--- a/Source/RP0/PartModules/ModuleShowInfo.cs
+++ b/Source/RP0/PartModules/ModuleShowInfo.cs
@@ -131,19 +131,18 @@ namespace RP0
             AvailablePart ap = part.partInfo;
             if (ap is null) return "";
 
+            string result = $"Tech Required: {ResearchAndDevelopment.GetTechnologyTitle(ap.TechRequired)}";
+
+            if (part.CrewCapacity > 0)
+                result += $"\nTraining course: {(TrainingDatabase.SynonymReplace(ap.name, out string name) ? name : ap.title)}";
+
             EntryCostDatabaseAccessor.Init();
             EntryCostDatabaseAccessor.GetFields();
-
-            string data = null;
             string nm = RealFuels.Utilities.SanitizeName(ap.name);
             if (HighLogic.LoadedScene != GameScenes.LOADING && EntryCostDatabase.GetHolder(nm) is PartEntryCostHolder h)
-                data = $"Total cost: {EntryCostDatabaseAccessor.GetCost(h)}\n{EntryCostDatabaseAccessor.DisplayHolder(h, false)}";
+                result += $"\nTotal cost: {EntryCostDatabaseAccessor.GetCost(h)}\n{EntryCostDatabaseAccessor.DisplayHolder(h, false)}";
 
-            string apInfo = $"Tech Required: {ap.TechRequired}";
-            if (part.CrewCapacity > 0)
-                apInfo = $"Training course: {(TrainingDatabase.SynonymReplace(ap.name, out string name) ? name : ap.title)}\n{apInfo}";
-
-            return $"Part name: {ap.name}\n{apInfo}\n{data}";
+            return result;
         }
 
         public override void OnStart(StartState state)

--- a/Source/RP0/PartModules/ModuleShowInfo.cs
+++ b/Source/RP0/PartModules/ModuleShowInfo.cs
@@ -131,7 +131,7 @@ namespace RP0
             AvailablePart ap = part.partInfo;
             if (ap is null) return "";
 
-            string result = $"Tech Required: {ResearchAndDevelopment.GetTechnologyTitle(ap.TechRequired)}";
+            string result = $"Part name: {ap.name}\nTech Required: {ResearchAndDevelopment.GetTechnologyTitle(ap.TechRequired)}";
 
             if (part.CrewCapacity > 0)
                 result += $"\nTraining course: {(TrainingDatabase.SynonymReplace(ap.name, out string name) ? name : ap.title)}";

--- a/Source/RP0/PartModules/ModuleShowInfo.cs
+++ b/Source/RP0/PartModules/ModuleShowInfo.cs
@@ -128,21 +128,22 @@ namespace RP0
 
         public override string GetInfo()
         {
+            AvailablePart ap = part.partInfo;
+            if (ap is null) return "";
+
             EntryCostDatabaseAccessor.Init();
             EntryCostDatabaseAccessor.GetFields();
 
-            string data = null, apInfo = null;
-            string nm = RealFuels.Utilities.SanitizeName(part.name);
+            string data = null;
+            string nm = RealFuels.Utilities.SanitizeName(ap.name);
             if (HighLogic.LoadedScene != GameScenes.LOADING && EntryCostDatabase.GetHolder(nm) is PartEntryCostHolder h)
                 data = $"Total cost: {EntryCostDatabaseAccessor.GetCost(h)}\n{EntryCostDatabaseAccessor.DisplayHolder(h, false)}";
-            if (part.partInfo is AvailablePart ap)
-            {
-                apInfo = $"Tech Required: {ap.TechRequired}";
-                if (part.CrewCapacity > 0)
-                    apInfo = $"Training course: {(TrainingDatabase.SynonymReplace(part.name, out string name) ? name : ap.title)}\n{apInfo}";
-            }
-            string res = $"Part name: {part.name}\n{apInfo}\n{data}";
-            return res;
+
+            string apInfo = $"Tech Required: {ap.TechRequired}";
+            if (part.CrewCapacity > 0)
+                apInfo = $"Training course: {(TrainingDatabase.SynonymReplace(ap.name, out string name) ? name : ap.title)}\n{apInfo}";
+
+            return $"Part name: {ap.name}\n{apInfo}\n{data}";
         }
 
         public override void OnStart(StartState state)


### PR DESCRIPTION
The `name` field on a `Part` is not always the part name; in particular when creating the tooltip in the editor for a part with upgrades, it is not (it is instead "{partName}(Clone)"). See also https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/177

Also, remove internal names from the info where possible. In particular,
- The part title is already the tooltip title, so it can just be removed;
- The tech now shows the title instead of the internal name;
- The training courses show an "internal" name in the RP-1 training window (they don't have a separate title), so I've left them as-is;
- ECM's don't have an user-facing title, so they're just left as-is.

Fixes an issue where the required crew training course name in the tooltip does not match the course name in the RP-1 training window.