### PR TITLE
Fix vessel transfers

### DIFF
--- a/GameData/RP-1/Contracts/Commercial Applications 1/EarlyComSat-CA.cfg
+++ b/GameData/RP-1/Contracts/Commercial Applications 1/EarlyComSat-CA.cfg
@@ -116,7 +116,6 @@ CONTRACT_TYPE
 		name = EarlyComSat
 		type = VesselParameterGroup
 		define = EarlyComSat
-		dissassociateVesselsOnContractCompletion = true
 		title = Communications Satellite (Early)
 
 		PARAMETER

--- a/GameData/RP-1/Contracts/Commercial Applications 1/EarlyMolniyaSat.cfg
+++ b/GameData/RP-1/Contracts/Commercial Applications 1/EarlyMolniyaSat.cfg
@@ -100,7 +100,6 @@ CONTRACT_TYPE
 		name = EarlyMolniya
 		type = VesselParameterGroup
 		define = EarlyMolniyaSat
-		dissassociateVesselsOnContractCompletion = true
 		title = Molniya Satellite
 
 		PARAMETER

--- a/GameData/RP-1/Contracts/Commercial Applications 1/EarlyNavSat-CA.cfg
+++ b/GameData/RP-1/Contracts/Commercial Applications 1/EarlyNavSat-CA.cfg
@@ -116,7 +116,6 @@ CONTRACT_TYPE
 		name = EarlyNavSat
 		type = VesselParameterGroup
 		define = EarlyNavSat
-		dissassociateVesselsOnContractCompletion = true
 		title = Navigation Satellite (Early)
 
 		PARAMETER

--- a/GameData/RP-1/Contracts/Earth Satellites/ComTestSat.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/ComTestSat.cfg
@@ -138,7 +138,6 @@ CONTRACT_TYPE
 		name = TestComSat
 		type = VesselParameterGroup
 		define = TestComSatellite
-		dissassociateVesselsOnContractCompletion = true
 		title = Communications test satellite
 
 		PARAMETER

--- a/GameData/RP-1/Contracts/Earth Satellites/EarlyComSat.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/EarlyComSat.cfg
@@ -140,7 +140,6 @@ CONTRACT_TYPE
 		name = EarlyComSat
 		type = VesselParameterGroup
 		define = EarlyComSatellite
-		dissassociateVesselsOnContractCompletion = true
 		title = Communications satellite (early)
 
 		PARAMETER

--- a/GameData/RP-1/Contracts/Earth Satellites/GEORepeatComSats.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/GEORepeatComSats.cfg
@@ -128,7 +128,6 @@ CONTRACT_TYPE
 		name = AdvComSat
 		type = VesselParameterGroup
 		define = AdvComSatellite
-		dissassociateVesselsOnContractCompletion = true
 		title = Commercial communications satellite
 
 		PARAMETER


### PR DESCRIPTION
Remove dissassociateVesselsOnContractCompletion on contracts that also have DestroyVessel on completion.  If the dissasociate happens first, there's nothing to destroy.