### PR TITLE
Balance-neutral cheap astro

### DIFF
--- a/GameData/RP-1/CustomBarnKit.cfg
+++ b/GameData/RP-1/CustomBarnKit.cfg
@@ -3,7 +3,7 @@
 	@ASTRONAUTS
 	{
 		@levels = 5
-		@upgrades = 60000, 30000, 150000, 300000, 1000000
+		@upgrades = 30000, 30000, 150000, 300000, 1000000
 		@upgradesVisual = 1, 1, 2, 2, 3
 		
 		@recruitHireBaseCost = 5000
@@ -25,7 +25,7 @@
 		@levels = 5
 		@upgradesVisual = 1, 2, 2, 3, 3
 		@unlockedFlightPlanning = 2
-		@upgrades = 25000, 60000, 120000, 200000, 300000 
+		@upgrades = 35000, 60000, 120000, 200000, 300000 
 		@activeContractsLimit = 3, 5, 7, 10, -1
 		@reputationKerbalDeath = 200
 		@reputationKerbalRecovery = 1
@@ -34,7 +34,7 @@
 	{
 		@levels = 10
 		@upgradesVisual = 1, 1, 2, 2, 2, 3, 3, 3, 3, 3
-		@upgrades = 50000, 50000, 50000, 100000, 175000, 100000, 150000, 1000000, 300000, 300000
+		@upgrades = 60000, 50000, 50000, 100000, 175000, 100000, 150000, 1000000, 300000, 300000
 		@unlockedSpaceObjectDiscovery = 8
 		@orbitDisplayMode = 2, 3, 3, 3, 3, 3, 3, 3, 3, 3
 		@patchesAheadLimit = 0, 1, 2, 3, 4, 4, 4, 4, 4, 4
@@ -50,7 +50,7 @@
 	{
 		@levels = 9
 		@upgradesVisual = 1, 1, 2, 2, 2, 3, 3, 3, 3
-		@upgrades = 25000, 40000, 140000, 250000, 400000, 500000, 500000, 500000, 500000
+		@upgrades = 35000, 40000, 140000, 250000, 400000, 500000, 500000, 500000, 500000
 		@activeStrategyLimit = 5, 6, 7, 8, 9, 10, 11, 12, 13
 		@strategyCommitRange = 0, 0, 0, 0, 0, 0, 0, 0, 0
 	}


### PR DESCRIPTION
Just did this in the web UI, haven't tested yet, but it makes the base astronaut complex cheaper to maintain and increases maintenance costs for other facilities to keep balance neutral while annoying no planes people less