### PR TITLE
Rebalance Optional Hypersonic Flight Contracts

### DIFF
--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesHypersonic.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesHypersonic.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 
 	title = X-Planes (Hypersonic)
 
-	description = <b>Program: X-Plane Research<br>Type: <color=green>Required</color></b><br><br>Design, build, and launch a crewed plane capable of hypersonic atmospheric flight of at least  @/minSpeedMPS km and return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.
+	description = <b>Program: X-Plane Research<br>Type: <color=green>Required</color></b><br><br>Design, build, and launch a crewed plane capable of hypersonic atmospheric flight of at least @/minSpeedMPS m/s below 40km and return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.
 	genericDescription = Design, build, and launch a crewed rocket or plane to put a person into high atmosphere above a specific altitude and return home safely.
 
 	synopsis = Launch a crewed vessel to @/minSpeedMPS m/s below 40km altitude.

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesHypersonicOptional.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesHypersonicOptional.cfg
@@ -5,10 +5,10 @@ CONTRACT_TYPE
 
 	title = X-Planes (Hypersonic) Optional
 
-	description = <b>Program: X-Plane Research<br>Type: <color=blue>Optional</color></b><br><br>Design, build, and launch a crewed plane capable of hypersonic atmospheric flight of at least  @/minSpeedMPS km and return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.
+	description = <b>Program: X-Plane Research<br>Type: <color=blue>Optional</color></b><br><br>Design, build, and launch a crewed plane capable of hypersonic atmospheric flight of at least @/minSpeedMPS m/s below 40km and return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.
 	genericDescription = Design, build, and launch a crewed rocket or plane to put a person into high atmosphere above a specific altitude and return home safely.
 
-	synopsis = Launch a crewed vessel to @/minSpeedMPS m/s below 40km altitude.
+	synopsis = Launch a crewed vessel to @/minSpeedMPS m/s for at least @/minDuration below 40km altitude.
 
 	completedMessage = Congratulations on a successful flight!
 	
@@ -76,7 +76,13 @@ CONTRACT_TYPE
 	DATA
 	{
 		type = List<float>
-		minSpeedsMPS = [ 2300, 2600 ]
+		minSpeedsMPS = [ 2000, 2000 ]
+	}
+		
+	DATA
+	{
+		type = List<Duration>
+		minDurations = [ 3m, 4m ]
 	}
 	
 	DATA
@@ -90,7 +96,14 @@ CONTRACT_TYPE
 		type = float
 		minSpeedMPS = @minSpeedsMPS.ElementAt(@index)
 	}
-
+	
+	DATA
+	{
+		type = Duration
+		minDuration = @minDurations.ElementAt(@index)
+		title = Duration
+	}
+	
 	PARAMETER
 	{
 		name = VesselGroup
@@ -138,7 +151,7 @@ CONTRACT_TYPE
 			{
 				name = Duration
 				type = Duration
-				duration = 2m
+				duration = @/minDuration
 				preWaitText = Reach specified speed.
 				waitingText = Testing hypersonic flight
 				completionText = Flight completed, you are cleared to land.


### PR DESCRIPTION
The current optional hypersonic flight contracts require speeds of 2300 m/s and 2600 m/s. The 2300 m/s contract is achievable, but only when using the non-inline X-15 cockpit. No parts exist with an aerodynamic shape, or that can be changed into an aerodynamic shape, which can withstand the temperatures encountered at those speeds.

In real life, no X-15 ever flew faster than 2020 m/s (Flight 188). That flight also essentially ruined the aircraft from thermal damage.
Because of this, believe that the differences in speed requirements should be dropped in favour of duration requirements.

I have changed the optional contracts to instead require the player to maintain 2000 m/s for longer, at three minutes for the first contract, and four minutes for the second. These are still difficult requirements to hit, but fall within the thermal limitations of something like the procedural nosecone.

I believe that these changes ensure that the confidence awarded by these contracts (150 on normal difficulty) is now more in-line with the craft required to perform them.