### PR TITLE
Fix missing contract Sat upgrade in early avionics node

### DIFF
--- a/GameData/RP-1/Tree/PayloadLevels.cfg
+++ b/GameData/RP-1/Tree/PayloadLevels.cfg
@@ -3,7 +3,7 @@ PARTUPGRADE
 {
 	name = RP-1-PayloadTech-EarlyAvionics
 	partIcon = RP-1-NavigationSat
-	techRequired = EarlyAvionics
+	techRequired = earlyAvionics
 	entryCost = 0
 	cost = 0
 	title = ComSat/NavSat Avionics Upgrade


### PR DESCRIPTION
EarlyAvionics upgrade for Com and Nav Sat's was missing from the tech tree due to a typo in the field techRequired in PayloadLevels.cfg

Tested this change in my local copy and it fixed the issue.