### PR TITLE
Increase Tundra orbit periapsis requirement

### DIFF
--- a/GameData/RP-1/Contracts/Commercial Applications 2/FirstTundraSat.cfg
+++ b/GameData/RP-1/Contracts/Commercial Applications 2/FirstTundraSat.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = CommApp2
 	agent = Federation Aeronautique Internationale
 
-	description = <b>Program: Advanced Commercial Applications<br>Type: <color=blue>Optional</color></b><br><br>A Tundra orbit is a highly elliptical geosynchronous orbit (note: not geostationary orbit) with a high inclination (usually near 63.4) and an orbital period of one sidereal day. A satellite placed in this orbit spends most of its time over a chosen area of the Earth, a phenomenon known as apogee dwell. The ground track of a satellite in a tundra orbit is a closed figure eight. An extreme version of this orbit puts the perigee around 1000 km and the apogee around 70,000 km. The orbit in this contract is actually using data from the Sirius satellites, the only known satellites using a Tundra orbit.<b>
+	description = <b>Program: Advanced Commercial Applications<br>Type: <color=blue>Optional</color></b><br><br>A Tundra orbit is a highly elliptical geosynchronous orbit (note: not geostationary orbit) with a high inclination (usually near 63.4) and an orbital period of one sidereal day. A satellite placed in this orbit spends most of its time over a chosen area of the Earth, a phenomenon known as apogee dwell. The ground track of a satellite in a tundra orbit is a closed figure eight. The orbit in this contract is actually using data from the Sirius satellites, the only known satellites using a Tundra orbit.<b>
 	synopsis = Launch a test satellite into a Tundra Orbit
 
 	completedMessage = Success! The Tundra orbit is highly eccentric and lets the satellite spend most of its time over a point in the high latitudes.
@@ -117,10 +117,10 @@ CONTRACT_TYPE
 			title = Reach the correct orbit within the parameters. Note: The argument of periapsis values mean that the apogee needs to be high in the northern latitudes. This is like a Molniya orbit, but with an orbital period the same as an Earth sidereal day.
 			minInclination = 61.4
 			maxInclination = 65.4
-			minEccentricity = 0.3
+			minEccentricity = 0.25
 			minArgumentOfPeriapsis = 220
 			maxArgumentOfPeriapsis = 320
-			minPeA = 1000000
+			minPeA = 17000000
 			minPeriod = 23h 54m 4s
 			maxPeriod = 23h 58m 4s
 

--- a/GameData/RP-1/Contracts/Earth Satellites/FirstTundraSat.cfg
+++ b/GameData/RP-1/Contracts/Earth Satellites/FirstTundraSat.cfg
@@ -7,7 +7,7 @@ CONTRACT_TYPE
 	
 	tag = exclude_EarlySatellite
 
-	description = <b>Program: Targeted Satellites<br>Type: <color=red>CAPSTONE</color></b><br><br>A Tundra orbit is a highly elliptical geosynchronous orbit (note: not geostationary orbit) with a high inclination (usually near 63.4) and an orbital period of one sidereal day. A satellite placed in this orbit spends most of its time over a chosen area of the Earth, a phenomenon known as apogee dwell. The ground track of a satellite in a tundra orbit is a closed figure eight. An extreme version of this orbit puts the perigee around 1000 km and the apogee around 70,000 km. The orbit in this contract is actually using data from the Sirius satellites, the only known satellites using a Tundra orbit.&br;&br;Place a satellite into a Tundra orbit.&br;&br;There will be an orbit showing in the map view and tracking station. You do not have to place the satellite into this orbit, but it is instead meant to show you where your perigee and apogee should approximately be located, but more importantly, it shows the proper shape of the orbit.
+	description = <b>Program: Targeted Satellites<br>Type: <color=red>CAPSTONE</color></b><br><br>A Tundra orbit is a highly elliptical geosynchronous orbit (note: not geostationary orbit) with a high inclination (usually near 63.4) and an orbital period of one sidereal day. A satellite placed in this orbit spends most of its time over a chosen area of the Earth, a phenomenon known as apogee dwell. The ground track of a satellite in a tundra orbit is a closed figure eight. The orbit in this contract is actually using data from the Sirius satellites, the only known satellites using a Tundra orbit.&br;&br;Place a satellite into a Tundra orbit.&br;&br;There will be an orbit showing in the map view and tracking station. You do not have to place the satellite into this orbit, but it is instead meant to show you where your perigee and apogee should approximately be located, but more importantly, it shows the proper shape of the orbit.
 
 	synopsis = Launch a satellite into a Tundra Orbit
 
@@ -121,10 +121,10 @@ CONTRACT_TYPE
 			title = Reach the correct orbit within the parameters. Note: The argument of periapsis values mean that the apogee needs to be high in the northern latitudes. This is like a Molniya orbit, but with an orbital period the same as an Earth sidereal day.
 			minInclination = 61.4
 			maxInclination = 65.4
-			minEccentricity = 0.3
+			minEccentricity = 0.25
 			minArgumentOfPeriapsis = 220
 			maxArgumentOfPeriapsis = 320
-			minPeA = 1000000
+			minPeA = 17000000
 			minPeriod = 23h 54m 4s
 			maxPeriod = 23h 58m 4s
 			


### PR DESCRIPTION
With a 1000 km periapsis (eccentricity 0.82), the resulting orbit has barely any apogee dwell time; it moves west very quickly across the sky when it's at apogee.

At an eccentricity of 0.423, the ground track moves from being a figure-of-eight to a teardrop shape.  Higher eccentricities make the ground track more of an oblong shape. An eccentricity of 0.423 gives a periapsis altitude of 17958 km; I've rounded it down to 17000 km to give a quite lot of margin.

Also decreased the minimum eccentricity a little bit. According to Capderou's "Handbook of Satellite Orbits", a 0.2668 eccentricity Tundra orbit was considered for ESA's "Archimedes" telecommunications project, giving an 8 hour visibility window per orbit. The new minimum of 0.25 is a little below that value.

Examples of Tundra orbits of varying eccentricity, with a waypoint at 63° latitude and a range of 3000 km:
![Tundra_groundtrack](https://github.com/KSP-RO/RP-1/assets/11440812/020acc1d-189d-41fe-a145-b27a341cd5ff)

Implements #2373