### PR TITLE
Parts Browser: Run queued changes in reverse

### DIFF
--- a/Source/Tech Tree/Parts Browser/app.py
+++ b/Source/Tech Tree/Parts Browser/app.py
@@ -145,7 +145,7 @@ def create_app(test_config=None):
     @app.route('/api/commit_changes',  methods=['POST'])
     def commit_changes():
         queued_changes = request.get_json()
-        for row_id in queued_changes['queued_changes']:
+        for row_id in reversed(queued_changes['queued_changes']):
             new_part = False
             part = None
             # if the part name changed, we need to use the old name to find it, else use the supplied name field


### PR DESCRIPTION
This prevents an edge case I encountered where the following occurs:
- The user creates a new part, and forgets to add certain info (in my case, I forgot to check the "RP-1" box), and presses "Queue Changes"
- The user edits that part, and queues those changes
- The user presses "Commit Changes to JSON Files"
- Operation fails, console shows exception:
```
Traceback (most recent call last):
  File "flask\app.py", line 2190, in wsgi_app
  File "flask\app.py", line 1486, in full_dispatch_request
  File "flask\app.py", line 1484, in full_dispatch_request
  File "flask\app.py", line 1469, in dispatch_request
  File "app.py", line 168, in commit_changes
    part_data.add_new_part(part)
  File "part_data.py", line 25, in add_new_part
    print(f'Adding new part with name: {new_part["name"]}')
                                        ~~~~~~~~^^^^^^^^
KeyError: 'name'
```

This is because the "edit" queued change is executed before the part is even created, causing issues. Running queued changes in reverse should prevent any issues with this in most cases, assuming the browser/frontend is sane and does not randomly order queued changes.

P.S. looks like GH decided to add a newline. If you want me to update the commit without that extra NL let me know.