### PR TITLE
Buff reward of far side landing optional and sample return contracts

### DIFF
--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonLandingFarSide.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonLandingFarSide.cfg
@@ -29,7 +29,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 150
+	rewardReputation = 250
 	failureReputation = 0 // was @rewardReputation
 
 	// ************ REQUIREMENTS ************

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonLandingFarSideOptional.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonLandingFarSideOptional.cfg
@@ -29,7 +29,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 300
+	rewardReputation = 250
 	failureReputation = 0 // was @rewardReputation
 
 	// ************ REQUIREMENTS ************

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonLandingFarSideOptional.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonLandingFarSideOptional.cfg
@@ -29,7 +29,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 150
+	rewardReputation = 300
 	failureReputation = 0 // was @rewardReputation
 
 	// ************ REQUIREMENTS ************

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonLandingReturn.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonLandingReturn.cfg
@@ -29,7 +29,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 200
+	rewardReputation = 400
 	failureReputation = 0 // was @rewardReputation
 
 	// ************ REQUIREMENTS ************


### PR DESCRIPTION
Currently, the reward for the lunar landing optional contracts are 200 reputation each. However, the sample return contract, which is far more difficult, gives the exact same reward, and furthermore the far side landing optional contract gives less of a reward?
I've fixed this problem by scaling the rewards roughly on difficulty. (for reference, Luna 16 (sample return) weighed 5.7t wet, while Luna 13 (lander) weighed 1.6t wet)