### PR TITLE
CI using CKAN

### DIFF
--- a/.github/workflows/attachReleaseArtifacts.yml
+++ b/.github/workflows/attachReleaseArtifacts.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]
     
+env:
+  KSP_ROOT: /tmp/ksp
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   attach-release-artifacts:
@@ -28,9 +31,22 @@ jobs:
         
       - name: Download required assemblies
         id: download-assemblies
-        uses: KSP-RO/BuildTools/download-assemblies@master
+        uses: KSP-RO/BuildTools/download-assemblies-v2@master
         with:
           KSP_ZIP_PASSWORD: ${{ secrets.KSP_ZIP_PASSWORD }}
+          dependency-identifiers: |
+            Harmony2
+            ClickThroughBlocker
+            ContractConfigurator
+            FerramAerospaceResearchContinued
+            Kerbalism
+            KSPCommunityFixes
+            ModularFlightIntegrator
+            RealAntennas
+            RealFuels
+            ROUtils
+            SolverEngines
+            ToolbarController
 
       # Install .NET SDKs
       - name: Setup .NET Core 3.1
@@ -45,27 +61,27 @@ jobs:
       - name: Update AssemblyInfo
         uses: KSP-RO/BuildTools/update-assembly-info@master
         with:
-          path: ${GITHUB_WORKSPACE}/Source/RP0/Properties/AssemblyInfo.cs
+          path: ${{ github.workspace }}/Source/RP0/Properties/AssemblyInfo.cs
           tag: ${{ github.event.release.tag_name }}
 
       - name: Build mod solution
-        run: msbuild ${GITHUB_WORKSPACE}/Source/RP0.sln /t:build /restore /p:RestorePackagesConfig=true /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}"
+        run: msbuild ${{ github.workspace }}/Source/RP0.sln /t:build /restore /p:RestorePackagesConfig=true /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}" /p:KSPRoot="${{ env.KSP_ROOT }}"
 
       - name: Remove excess DLLs
         uses: KSP-RO/BuildTools/remove-excess-dlls@master
         with:
-          path: ${GITHUB_WORKSPACE}/GameData/
+          path: ${{ github.workspace }}/GameData/
         
       - name: Update version file
         uses: KSP-RO/BuildTools/update-version-file@master
         with:
           tag: ${{ github.event.release.tag_name }}
-          path: ${GITHUB_WORKSPACE}/GameData/RP-1/RP-1.version
+          path: ${{ github.workspace }}/GameData/RP-1/RP-1.version
 
       - name: Update Readme
         uses: KSP-RO/BuildTools/update-version-in-readme@master
         with:
-          path: ${GITHUB_WORKSPACE}/README.md
+          path: ${{ github.workspace }}/README.md
           tag: ${{ github.event.release.tag_name }}
           
       - name: Update changelog file
@@ -73,7 +89,7 @@ jobs:
         with:
           tag: ${{ github.event.release.tag_name }}
           body: ${{ github.event.release.body }}
-          path: ${GITHUB_WORKSPACE}/GameData/RP-1/changelog.cfg
+          path: ${{ github.workspace }}/GameData/RP-1/changelog.cfg
           
       - name: Assemble release
         id: assemble-release
@@ -83,8 +99,8 @@ jobs:
           echo "Release zip: ${RELEASE_DIR}/RP-1-${{ github.event.release.tag_name }}.zip"
           mkdir -v "${RELEASE_DIR}"
           echo "::set-output name=release-dir::${RELEASE_DIR}"
-          cp -v -R "${GITHUB_WORKSPACE}/GameData" "${RELEASE_DIR}"
-          cp -v -R "${GITHUB_WORKSPACE}/LICENSE.md" "${RELEASE_DIR}/GameData/RP-1/LICENSE.md"
+          cp -v -R "${{ github.workspace }}/GameData" "${RELEASE_DIR}"
+          cp -v -R "${{ github.workspace }}/LICENSE.md" "${RELEASE_DIR}/GameData/RP-1/LICENSE.md"
           cd ${RELEASE_DIR}
           zip -r RP-1-${{ github.event.release.tag_name }}.zip GameData
         
@@ -109,9 +125,9 @@ jobs:
           TAG_STRING: ${{ github.event.release.tag_name }}
         run: |
           RELEASEBRANCH=${{ env.tagged_branch }}
-          git add "${GITHUB_WORKSPACE}/GameData/RP-1/RP-1.version"
-          git add "${GITHUB_WORKSPACE}/README.md"
-          git add "${GITHUB_WORKSPACE}/GameData/RP-1/changelog.cfg"
+          git add "${{ github.workspace }}/GameData/RP-1/RP-1.version"
+          git add "${{ github.workspace }}/README.md"
+          git add "${{ github.workspace }}/GameData/RP-1/changelog.cfg"
           git commit -m "Update version to $TAG_STRING"
           git push origin $RELEASEBRANCH
           git tag $TAG_STRING $RELEASEBRANCH --force

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  KSP_ROOT: /tmp/ksp
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   check-secret:
@@ -38,9 +41,22 @@ jobs:
 
       - name: Download required assemblies
         id: download-assemblies
-        uses: KSP-RO/BuildTools/download-assemblies@master
+        uses: KSP-RO/BuildTools/download-assemblies-v2@master
         with:
           KSP_ZIP_PASSWORD: ${{ secrets.KSP_ZIP_PASSWORD }}
+          dependency-identifiers: |
+            Harmony2
+            ClickThroughBlocker
+            ContractConfigurator
+            FerramAerospaceResearchContinued
+            Kerbalism
+            KSPCommunityFixes
+            ModularFlightIntegrator
+            RealAntennas
+            RealFuels
+            ROUtils
+            SolverEngines
+            ToolbarController
 
       - name: Get SHA
         id: get-sha
@@ -70,22 +86,22 @@ jobs:
       - name: Update AssemblyInfo
         uses: KSP-RO/BuildTools/update-assembly-info@AssemblyInformationalVersion
         with:
-          path: ${GITHUB_WORKSPACE}/Source/RP0/Properties/AssemblyInfo.cs
+          path: ${{ github.workspace }}/Source/RP0/Properties/AssemblyInfo.cs
           tag: "3.0.0.0"
           informational-version: ${{env.info_text}}
 
       - name: Build mod solution
-        run: msbuild ${GITHUB_WORKSPACE}/Source/RP0.sln /t:build /restore /p:RestorePackagesConfig=true /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}"
+        run: msbuild ${{ github.workspace }}/Source/RP0.sln /t:build /restore /p:RestorePackagesConfig=true /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}" /p:KSPRoot="${{ env.KSP_ROOT }}"
 
       - name: Remove excess DLLs
         uses: KSP-RO/BuildTools/remove-excess-dlls@master
         with:
-          path: ${GITHUB_WORKSPACE}/GameData/
+          path: ${{ github.workspace }}/GameData/
 
       - name: Build metadata
         uses: KSP-RO/BuildTools/update-version-file@master
         with:
-          path: ${GITHUB_WORKSPACE}/GameData/RP-1/RP-1.version
+          path: ${{ github.workspace }}/GameData/RP-1/RP-1.version
           tag: "v3.0.0.0"
 
       - name: Assemble release
@@ -95,8 +111,8 @@ jobs:
           echo "Release dir: ${RELEASE_DIR}"
           mkdir -v "${RELEASE_DIR}"
           echo "::set-output name=release-dir::${RELEASE_DIR}"
-          cp -v -R "${GITHUB_WORKSPACE}/GameData" "${RELEASE_DIR}"
-          cp -v -R "${GITHUB_WORKSPACE}/LICENSE.md" "${RELEASE_DIR}/GameData/RP-1/LICENSE.md"
+          cp -v -R "${{ github.workspace }}/GameData" "${RELEASE_DIR}"
+          cp -v -R "${{ github.workspace }}/LICENSE.md" "${RELEASE_DIR}/GameData/RP-1/LICENSE.md"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v1

--- a/Source/CC_RP0/CC_RP0.csproj
+++ b/Source/CC_RP0/CC_RP0.csproj
@@ -33,24 +33,33 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup>
+    <KSPRoot Condition=" '$(KSPRoot)' == '' ">
+      $(ReferencePath.TrimEnd([System.IO.Path]::DirectorySeparatorChar))</KSPRoot>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp.dll">
+      <HintPath>$(ReferencePath)/Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp-firstpass.dll">
+      <HintPath>$(ReferencePath)/Assembly-CSharp-firstpass.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ContractConfigurator">
+    <Reference Include="$(KSPRoot)/GameData/ContractConfigurator/ContractConfigurator.dll">
+      <HintPath>$(ReferencePath)/ContractConfigurator.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.dll">
+      <HintPath>$(ReferencePath)/System.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.CoreModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Source/ClearInputLocks/ClearInputLocks.csproj
+++ b/Source/ClearInputLocks/ClearInputLocks.csproj
@@ -36,25 +36,33 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup>
+    <KSPRoot Condition=" '$(KSPRoot)' == '' ">
+      $(ReferencePath.TrimEnd([System.IO.Path]::DirectorySeparatorChar))</KSPRoot>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp.dll">
+      <HintPath>$(ReferencePath)/Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp-firstpass.dll">
+      <HintPath>$(ReferencePath)/Assembly-CSharp-firstpass.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.dll">
+      <HintPath>$(ReferencePath)/System.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.CoreModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.InputLegacyModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.InputLegacyModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.InputLegacyModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Source/InstallChecker/RP0InstallChecker.csproj
+++ b/Source/InstallChecker/RP0InstallChecker.csproj
@@ -33,12 +33,21 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
+  <PropertyGroup>
+    <KSPRoot Condition=" '$(KSPRoot)' == '' ">
+      $(ReferencePath.TrimEnd([System.IO.Path]::DirectorySeparatorChar))</KSPRoot>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp.dll">
+      <HintPath>$(ReferencePath)/Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="UnityEngine.CoreModule">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.dll">
+      <HintPath>$(ReferencePath)/System.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.CoreModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Source/RP0/RP0.csproj
+++ b/Source/RP0/RP0.csproj
@@ -35,6 +35,10 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup>
+    <KSPRoot Condition=" '$(KSPRoot)' == '' ">
+      $(ReferencePath.TrimEnd([System.IO.Path]::DirectorySeparatorChar))</KSPRoot>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Avionics\ControlLockerUtils.cs" />
     <Compile Include="Avionics\EditorBinder.cs" />
@@ -279,99 +283,124 @@
     <Compile Include="SpaceCenter\VesselBuildValidator.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="$(KSPRoot)/GameData/000_Harmony/0Harmony.dll">
+      <HintPath>$(ReferencePath)/0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Assembly-CSharp">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp.dll">
+      <HintPath>$(ReferencePath)/Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp-firstpass.dll">
+      <HintPath>$(ReferencePath)/Assembly-CSharp-firstpass.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ClickThroughBlocker">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="$(KSPRoot)/GameData/000_ClickThroughBlocker/Plugins/ClickThroughBlocker.dll">
+      <HintPath>$(ReferencePath)/ClickThroughBlocker.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ContractConfigurator, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="$(KSPRoot)/GameData/ContractConfigurator/ContractConfigurator.dll">
+      <HintPath>$(ReferencePath)/ContractConfigurator.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ferramGraph">
+    <Reference Include="$(KSPRoot)/GameData/FerramAerospaceResearch/Plugins/ferramGraph.dll">
+      <HintPath>$(ReferencePath)/ferramGraph.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Ionic.Zip, Version=1.9.1.8, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Ionic.Zip.dll">
+      <HintPath>$(ReferencePath)/Ionic.Zip.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Kerbalism112, Version=3.17.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="$(KSPRoot)/GameData/Kerbalism/Kerbalism112.kbin">
+      <HintPath>$(ReferencePath)/Kerbalism112.kbin</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="KSPCommunityFixes">
+    <Reference Include="$(KSPRoot)/GameData/KSPCommunityFixes/Plugins/KSPCommunityFixes.dll">
+      <HintPath>$(ReferencePath)/KSPCommunityFixes.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ModularFlightIntegrator">
+    <Reference Include="$(KSPRoot)/GameData/ModularFlightIntegrator/ModularFlightIntegrator.dll">
+      <HintPath>$(ReferencePath)/ModularFlightIntegrator.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="RealAntennas">
+    <Reference Include="$(KSPRoot)/GameData/RealAntennas/Plugins/RealAntennas.dll">
+      <HintPath>$(ReferencePath)/RealAntennas.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="RealFuels">
+    <Reference Include="$(KSPRoot)/GameData/RealFuels/Plugins/RealFuels.dll">
+      <HintPath>$(ReferencePath)/RealFuels.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ROUtils">
+    <Reference Include="$(KSPRoot)/GameData/ROUtils/Plugins/ROUtils.dll">
+      <HintPath>$(ReferencePath)/ROUtils.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="SolverEngines">
+    <Reference Include="$(KSPRoot)/GameData/SolverEngines/Plugins/SolverEngines.dll">
+      <HintPath>$(ReferencePath)/SolverEngines.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/System.dll">
+      <HintPath>$(ReferencePath)/System.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ToolbarControl">
+    <Reference Include="$(KSPRoot)/GameData/001_ToolbarControl/Plugins/ToolbarControl.dll">
+      <HintPath>$(ReferencePath)/ToolbarControl.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.AnimationModule">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.AnimationModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.AnimationModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.AssetBundleModule">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.AssetBundleModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.AssetBundleModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.CoreModule">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.CoreModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.ImageConversionModule">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.ImageConversionModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.IMGUIModule">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.IMGUIModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.InputLegacyModule">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.InputLegacyModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.InputLegacyModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.PhysicsModule">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.PhysicsModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.PhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.ScreenCaptureModule">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.ScreenCaptureModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.ScreenCaptureModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.TextRenderingModule">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.TextRenderingModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.UI">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.UI.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.UIModule">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.UIModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.UIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.UnityWebRequestModule">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.UnityWebRequestModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.UnityWebRequestModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.JSONSerializeModule">
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.JSONSerializeModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.JSONSerializeModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
This PR changes the csproj to use paths relative to `KSPRoot` and also updates the workflows for CI to use CKAN to install dependencies.
Custom dlls can still be provided by adding them to this repo: https://github.com/KSP-RO/BuildLibs

If `KSPRoot` is not set, `ReferencePath` will be used instead. With this behaviour `ReferencePath` can be set to either a folder with all references, or to a KSP install for local development