### PR TITLE
Make targeted moon landing easier

### DIFF
--- a/GameData/RP-1/Contracts/Lunar Crewed/CrewedMoonLandingTargeted.cfg
+++ b/GameData/RP-1/Contracts/Lunar Crewed/CrewedMoonLandingTargeted.cfg
@@ -8,7 +8,7 @@ CONTRACT_TYPE
 
 	description = <b>Program: Crewed Lunar Exploration<br>Type: <color=red>CAPSTONE</color></b><br><br>Design and launch a spacecraft with at least one crew member to land at a specific location on the Moon. Explore the area for at least @/LandDur and then return safely to Earth.&br;&br;<b>Number of Contracts Completed: @index / @maxCompletions</b>
 
-	genericDescription = Launch a crewed single-person spacecraft and land it on a specific lunar biome. Explore the area for the specified amount of time and then return safely to Earth.
+	genericDescription = Launch a spacecraft with at least one crew member and land it on a specific lunar biome. Explore the area for the specified amount of time and then return safely to Earth.
 
 	synopsis = Land a crew on a specific biome on the Moon and return safely to Earth
 
@@ -28,12 +28,12 @@ CONTRACT_TYPE
 	targetBody = Moon
 
 	// ************ REWARDS ************
-	prestige = Trivial       // 1.0x
+	prestige = Trivial	   // 1.0x
 	advanceFunds = 0
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 1000+(250 * @/index)
+	rewardReputation = 750+(250 * @/index)
 	failureReputation = 0
 
 
@@ -153,7 +153,7 @@ CONTRACT_TYPE
 	{
 		name = vesselGroup
 		type = VesselParameterGroup
-		title = Crewed lunar landing
+		title = Crewed targeted lunar landing
 		
 		PARAMETER
 		{
@@ -221,14 +221,15 @@ CONTRACT_TYPE
 			{
 				name = TargetedLanding
 				type = Any
+				completeInSequence = true
 				
 				PARAMETER
 				{
 					name = Mare Tranquillitatis
 					type = VisitWaypoint
 					index = 0
-					distance = 1000.0
-					title = Land within 1km of @/String11
+					distance = 25000.0
+					title = Land within 25km of @/String11
 					showMessages = true
 					disableOnStateChange = true
 					hideChildren = true
@@ -239,8 +240,8 @@ CONTRACT_TYPE
 					name = Oceanus Procellarum
 					type = VisitWaypoint
 					index = 1
-					distance = 1000.0
-					title = Land within 1km of @/String12
+					distance = 25000.0
+					title = Land within 25km of @/String12
 					showMessages = true
 					disableOnStateChange = true
 					hideChildren = true
@@ -251,8 +252,8 @@ CONTRACT_TYPE
 					name = Fra Mauro
 					type = VisitWaypoint
 					index = 2
-					distance = 1000.0
-					title = Land within 1km of @/String14
+					distance = 25000.0
+					title = Land within 25km of @/String14
 					showMessages = true
 					disableOnStateChange = true
 					hideChildren = true
@@ -263,8 +264,8 @@ CONTRACT_TYPE
 					name = Hadley-Apennines
 					type = VisitWaypoint
 					index = 3
-					distance = 1000.0
-					title = Land within 1km of @/String15
+					distance = 25000.0
+					title = Land within 25km of @/String15
 					showMessages = true
 					disableOnStateChange = true
 					hideChildren = true
@@ -275,8 +276,8 @@ CONTRACT_TYPE
 					name = Descartes
 					type = VisitWaypoint
 					index = 4
-					distance = 1000.0
-					title = Land within 1km of @/String16
+					distance = 25000.0
+					title = Land within 25km of @/String16
 					showMessages = true
 					disableOnStateChange = true
 					hideChildren = true
@@ -287,8 +288,8 @@ CONTRACT_TYPE
 					name = Taurus-Littrow
 					type = VisitWaypoint
 					index = 5
-					distance = 1000.0
-					title = Land within 1km of @/String17
+					distance = 25000.0
+					title = Land within 25km of @/String17
 					showMessages = true
 					disableOnStateChange = true
 					hideChildren = true
@@ -296,6 +297,138 @@ CONTRACT_TYPE
 			}
 		}
 		
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return home safely
+			hideChildren = true
+			completeInSequence = true
+		}
+	}
+	
+	PARAMETER
+	{
+		name = OptVesselGroup
+		type = VesselParameterGroup
+		title = Demonstrate precision landing and land within 3km of target locations
+		rewardReputation = 50
+		rewardScience = 5
+		optional = true
+		hideChildren = false
+		
+		PARAMETER
+		{
+			name = LandCrewed
+			type = All
+			title = Land the crewed lander
+			disableOnStateChange = true
+			hideChildren = true
+			
+			PARAMETER
+			{
+				title = Have at least 1 crewmember on board
+				name = TwoCrew
+				type = HasCrew
+				minCrew = 1
+				crewOnly = true
+				hideChildren = true
+			}
+			
+			PARAMETER
+			{
+				title = Land the crewed lander
+				name = ReachState
+				type = ReachState
+				targetBody = Moon
+				disableOnStateChange = true
+				situation = LANDED
+				hideChildren = true
+			}
+		}
+
+		
+		PARAMETER
+		{
+			title = Land within 3km of target locations
+			name = TargetedLandingOptional
+			type = Any
+			hideChildren = true
+			completeInSequence = true
+			
+			PARAMETER
+			{
+				name = Mare Tranquillitatis
+				type = VisitWaypoint
+				index = 0
+				distance = 3000.0
+				title = Land within 3km of @/String11
+				showMessages = true
+				disableOnStateChange = true
+				hideChildren = true
+			}
+			
+			PARAMETER
+			{
+				name = Oceanus Procellarum
+				type = VisitWaypoint
+				index = 1
+				distance = 3000.0
+				title = Land within 3km of @/String12
+				showMessages = true
+				disableOnStateChange = true
+				hideChildren = true
+			}
+			
+			PARAMETER
+			{
+				name = Fra Mauro
+				type = VisitWaypoint
+				index = 2
+				distance = 3000.0
+				title = Land within 3km of @/String14
+				showMessages = true
+				disableOnStateChange = true
+				hideChildren = true
+			}
+			
+			PARAMETER
+			{
+				name = Hadley-Apennines
+				type = VisitWaypoint
+				index = 3
+				distance = 3000.0
+				title = Land within 3km of @/String15
+				showMessages = true
+				disableOnStateChange = true
+				hideChildren = true
+			}
+			
+			PARAMETER
+			{
+				name = Descartes
+				type = VisitWaypoint
+				index = 4
+				distance = 3000.0
+				title = Land within 3km of @/String16
+				showMessages = true
+				disableOnStateChange = true
+				hideChildren = true
+			}
+			
+			PARAMETER
+			{
+				name = Taurus-Littrow
+				type = VisitWaypoint
+				index = 5
+				distance = 3000.0
+				title = Land within 3km of @/String17
+				showMessages = true
+				disableOnStateChange = true
+				hideChildren = true
+			}
+		}
+
 		PARAMETER
 		{
 			name = ReturnHome

--- a/GameData/RP-1/Contracts/Lunar Crewed/CrewedMoonLandingTargeted.cfg
+++ b/GameData/RP-1/Contracts/Lunar Crewed/CrewedMoonLandingTargeted.cfg
@@ -163,15 +163,6 @@ CONTRACT_TYPE
 			hideChildren = true
 		}
 
-		PARAMETER
-		{
-			name = TwoCrew
-			type = HasCrew
-			minCrew = 1
-			crewOnly = true
-			title = Have at least 1 crewmember on board
-			hideChildren = true
-		}
 
 		PARAMETER
 		{
@@ -208,7 +199,7 @@ CONTRACT_TYPE
                 
                 PARAMETER
                 {
-                    title = Land within 3km of ANY target location
+                    title = Land near ANY target location
                     name = TargetedLanding
                     type = Any
                     
@@ -305,7 +296,7 @@ CONTRACT_TYPE
 	{
 		name = OptVesselGroup
 		type = VesselParameterGroup
-		title = Demonstrate precision landing and land within 3km of ANY target location
+		title = Demonstrate precision landing
 		rewardReputation = 50
 		rewardScience = 5
 		optional = true
@@ -315,7 +306,7 @@ CONTRACT_TYPE
 		{
 			name = LandCrewed
 			type = All
-			title = Land a crewed vessel within 3km of one of ANY target locations
+			title = Land a crewed vessel within 3km of ANY target location
 			disableOnStateChange = true
 			hideChildren = true
 			

--- a/GameData/RP-1/Contracts/Lunar Crewed/CrewedMoonLandingTargeted.cfg
+++ b/GameData/RP-1/Contracts/Lunar Crewed/CrewedMoonLandingTargeted.cfg
@@ -28,7 +28,7 @@ CONTRACT_TYPE
 	targetBody = Moon
 
 	// ************ REWARDS ************
-	prestige = Trivial	   // 1.0x
+	prestige = Trivial  // 1.0x
 	advanceFunds = 0
 	rewardScience = 0
 	rewardFunds = 0
@@ -197,78 +197,78 @@ CONTRACT_TYPE
 					situation = LANDED
 				}
                 
-                PARAMETER
-                {
-                    title = Land near ANY target location
-                    name = TargetedLanding
-                    type = Any
-                    
-                    PARAMETER
-                    {
-                        name = Mare Tranquillitatis
-                        type = VisitWaypoint
-                        index = 0
-                        distance = 10000.0
-                        title = Land within 10km of @/String11
-                        showMessages = true
-                        hideChildren = true
-                    }
-                    
-                    PARAMETER
-                    {
-                        name = Oceanus Procellarum
-                        type = VisitWaypoint
-                        index = 1
-                        distance = 10000.0
-                        title = Land within 10km of @/String12
-                        showMessages = true
-                        hideChildren = true
-                    }
-                    
-                    PARAMETER
-                    {
-                        name = Fra Mauro
-                        type = VisitWaypoint
-                        index = 2
-                        distance = 10000.0
-                        title = Land within 10km of @/String14
-                        showMessages = true
-                        hideChildren = true
-                    }
-                    
-                    PARAMETER
-                    {
-                        name = Hadley-Apennines
-                        type = VisitWaypoint
-                        index = 3
-                        distance = 10000.0
-                        title = Land within 10km of @/String15
-                        showMessages = true
-                        hideChildren = true
-                    }
-                    
-                    PARAMETER
-                    {
-                        name = Descartes
-                        type = VisitWaypoint
-                        index = 4
-                        distance = 10000.0
-                        title = Land within 10km of @/String16
-                        showMessages = true
-                        hideChildren = true
-                    }
-                    
-                    PARAMETER
-                    {
-                        name = Taurus-Littrow
-                        type = VisitWaypoint
-                        index = 5
-                        distance = 10000.0
-                        title = Land within 10km of @/String17
-                        showMessages = true
-                        hideChildren = true
-                    }
-                }
+		                PARAMETER
+		                {
+		                    title = Land within 10km of ANY target location
+		                    name = TargetedLanding
+		                    type = Any
+		                    
+		                    PARAMETER
+		                    {
+		                        name = Mare Tranquillitatis
+		                        type = VisitWaypoint
+		                        index = 0
+		                        distance = 10000.0
+		                        title = Land within 10km of @/String11
+		                        showMessages = true
+		                        hideChildren = true
+		                    }
+		                    
+		                    PARAMETER
+		                    {
+		                        name = Oceanus Procellarum
+		                        type = VisitWaypoint
+		                        index = 1
+		                        distance = 10000.0
+		                        title = Land within 10km of @/String12
+		                        showMessages = true
+		                        hideChildren = true
+		                    }
+		                    
+		                    PARAMETER
+		                    {
+		                        name = Fra Mauro
+		                        type = VisitWaypoint
+		                        index = 2
+		                        distance = 10000.0
+		                        title = Land within 10km of @/String14
+		                        showMessages = true
+		                        hideChildren = true
+		                    }
+		                    
+		                    PARAMETER
+		                    {
+		                        name = Hadley-Apennines
+		                        type = VisitWaypoint
+		                        index = 3
+		                        distance = 10000.0
+		                        title = Land within 10km of @/String15
+		                        showMessages = true
+		                        hideChildren = true
+		                    }
+		                    
+		                    PARAMETER
+		                    {
+		                        name = Descartes
+		                        type = VisitWaypoint
+		                        index = 4
+		                        distance = 10000.0
+		                        title = Land within 10km of @/String16
+		                        showMessages = true
+		                        hideChildren = true
+		                    }
+		                    
+		                    PARAMETER
+		                    {
+		                        name = Taurus-Littrow
+		                        type = VisitWaypoint
+		                        index = 5
+		                        distance = 10000.0
+		                        title = Land within 10km of @/String17
+		                        showMessages = true
+		                        hideChildren = true
+		                    }
+		                }
 				
 				PARAMETER
 				{
@@ -330,80 +330,80 @@ CONTRACT_TYPE
 				hideChildren = true
 			}
             
-            PARAMETER
-            {
-                title = Land within 3km of ANY target location
-                name = TargetedLandingOptional
-                type = Any
-                hideChildren = true
-                completeInSequence = true
-                
-                PARAMETER
-                {
-                    name = Mare Tranquillitatis
-                    type = VisitWaypoint
-                    index = 0
-                    distance = 3000.0
-                    title = Land within 3km of @/String11
-                    showMessages = true
-                    hideChildren = true
-                }
-                
-                PARAMETER
-                {
-                    name = Oceanus Procellarum
-                    type = VisitWaypoint
-                    index = 1
-                    distance = 3000.0
-                    title = Land within 3km of @/String12
-                    showMessages = true
-                    hideChildren = true
-                }
-                
-                PARAMETER
-                {
-                    name = Fra Mauro
-                    type = VisitWaypoint
-                    index = 2
-                    distance = 3000.0
-                    title = Land within 3km of @/String14
-                    showMessages = true
-                    hideChildren = true
-                }
-                
-                PARAMETER
-                {
-                    name = Hadley-Apennines
-                    type = VisitWaypoint
-                    index = 3
-                    distance = 3000.0
-                    title = Land within 3km of @/String15
-                    showMessages = true
-                    hideChildren = true
-                }
-                
-                PARAMETER
-                {
-                    name = Descartes
-                    type = VisitWaypoint
-                    index = 4
-                    distance = 3000.0
-                    title = Land within 3km of @/String16
-                    showMessages = true
-                    hideChildren = true
-                }
-                
-                PARAMETER
-                {
-                    name = Taurus-Littrow
-                    type = VisitWaypoint
-                    index = 5
-                    distance = 3000.0
-                    title = Land within 3km of @/String17
-                    showMessages = true
-                    hideChildren = true
-                }
-            }
+			PARAMETER
+			{
+				title = Land within 3km of ANY target location
+				name = TargetedLandingOptional
+				type = Any
+				hideChildren = true
+				completeInSequence = true
+
+				PARAMETER
+				{
+				    name = Mare Tranquillitatis
+				    type = VisitWaypoint
+				    index = 0
+				    distance = 3000.0
+				    title = Land within 3km of @/String11
+				    showMessages = true
+				    hideChildren = true
+				}
+				
+				PARAMETER
+				{
+				    name = Oceanus Procellarum
+				    type = VisitWaypoint
+				    index = 1
+				    distance = 3000.0
+				    title = Land within 3km of @/String12
+				    showMessages = true
+				    hideChildren = true
+				}
+				
+				PARAMETER
+				{
+				    name = Fra Mauro
+				    type = VisitWaypoint
+				    index = 2
+				    distance = 3000.0
+				    title = Land within 3km of @/String14
+				    showMessages = true
+				    hideChildren = true
+				}
+				
+				PARAMETER
+				{
+				    name = Hadley-Apennines
+				    type = VisitWaypoint
+				    index = 3
+				    distance = 3000.0
+				    title = Land within 3km of @/String15
+				    showMessages = true
+				    hideChildren = true
+				}
+				
+				PARAMETER
+				{
+				    name = Descartes
+				    type = VisitWaypoint
+				    index = 4
+				    distance = 3000.0
+				    title = Land within 3km of @/String16
+				    showMessages = true
+				    hideChildren = true
+				}
+				
+				PARAMETER
+				{
+				    name = Taurus-Littrow
+				    type = VisitWaypoint
+				    index = 5
+				    distance = 3000.0
+				    title = Land within 3km of @/String17
+				    showMessages = true
+				    hideChildren = true
+				}
+			}
 		}
 
 		PARAMETER

--- a/GameData/RP-1/Contracts/Lunar Crewed/CrewedMoonLandingTargeted.cfg
+++ b/GameData/RP-1/Contracts/Lunar Crewed/CrewedMoonLandingTargeted.cfg
@@ -205,6 +205,79 @@ CONTRACT_TYPE
 					targetBody = Moon
 					situation = LANDED
 				}
+                
+                PARAMETER
+                {
+                    title = Land within 3km of ANY target location
+                    name = TargetedLanding
+                    type = Any
+                    
+                    PARAMETER
+                    {
+                        name = Mare Tranquillitatis
+                        type = VisitWaypoint
+                        index = 0
+                        distance = 10000.0
+                        title = Land within 10km of @/String11
+                        showMessages = true
+                        hideChildren = true
+                    }
+                    
+                    PARAMETER
+                    {
+                        name = Oceanus Procellarum
+                        type = VisitWaypoint
+                        index = 1
+                        distance = 10000.0
+                        title = Land within 10km of @/String12
+                        showMessages = true
+                        hideChildren = true
+                    }
+                    
+                    PARAMETER
+                    {
+                        name = Fra Mauro
+                        type = VisitWaypoint
+                        index = 2
+                        distance = 10000.0
+                        title = Land within 10km of @/String14
+                        showMessages = true
+                        hideChildren = true
+                    }
+                    
+                    PARAMETER
+                    {
+                        name = Hadley-Apennines
+                        type = VisitWaypoint
+                        index = 3
+                        distance = 10000.0
+                        title = Land within 10km of @/String15
+                        showMessages = true
+                        hideChildren = true
+                    }
+                    
+                    PARAMETER
+                    {
+                        name = Descartes
+                        type = VisitWaypoint
+                        index = 4
+                        distance = 10000.0
+                        title = Land within 10km of @/String16
+                        showMessages = true
+                        hideChildren = true
+                    }
+                    
+                    PARAMETER
+                    {
+                        name = Taurus-Littrow
+                        type = VisitWaypoint
+                        index = 5
+                        distance = 10000.0
+                        title = Land within 10km of @/String17
+                        showMessages = true
+                        hideChildren = true
+                    }
+                }
 				
 				PARAMETER
 				{
@@ -214,85 +287,6 @@ CONTRACT_TYPE
 					preWaitText = Land on the moon.
 					waitingText = Exploring...
 					completionText = Exploration completed, you may return to Earth when ready.
-				}
-			}
-			
-			PARAMETER
-			{
-				name = TargetedLanding
-				type = Any
-				completeInSequence = true
-				
-				PARAMETER
-				{
-					name = Mare Tranquillitatis
-					type = VisitWaypoint
-					index = 0
-					distance = 25000.0
-					title = Land within 25km of @/String11
-					showMessages = true
-					disableOnStateChange = true
-					hideChildren = true
-				}
-				
-				PARAMETER
-				{
-					name = Oceanus Procellarum
-					type = VisitWaypoint
-					index = 1
-					distance = 25000.0
-					title = Land within 25km of @/String12
-					showMessages = true
-					disableOnStateChange = true
-					hideChildren = true
-				}
-				
-				PARAMETER
-				{
-					name = Fra Mauro
-					type = VisitWaypoint
-					index = 2
-					distance = 25000.0
-					title = Land within 25km of @/String14
-					showMessages = true
-					disableOnStateChange = true
-					hideChildren = true
-				}
-				
-				PARAMETER
-				{
-					name = Hadley-Apennines
-					type = VisitWaypoint
-					index = 3
-					distance = 25000.0
-					title = Land within 25km of @/String15
-					showMessages = true
-					disableOnStateChange = true
-					hideChildren = true
-				}
-				
-				PARAMETER
-				{
-					name = Descartes
-					type = VisitWaypoint
-					index = 4
-					distance = 25000.0
-					title = Land within 25km of @/String16
-					showMessages = true
-					disableOnStateChange = true
-					hideChildren = true
-				}
-				
-				PARAMETER
-				{
-					name = Taurus-Littrow
-					type = VisitWaypoint
-					index = 5
-					distance = 25000.0
-					title = Land within 25km of @/String17
-					showMessages = true
-					disableOnStateChange = true
-					hideChildren = true
 				}
 			}
 		}
@@ -311,7 +305,7 @@ CONTRACT_TYPE
 	{
 		name = OptVesselGroup
 		type = VesselParameterGroup
-		title = Demonstrate precision landing and land within 3km of target locations
+		title = Demonstrate precision landing and land within 3km of ANY target location
 		rewardReputation = 50
 		rewardScience = 5
 		optional = true
@@ -321,7 +315,7 @@ CONTRACT_TYPE
 		{
 			name = LandCrewed
 			type = All
-			title = Land the crewed lander
+			title = Land a crewed vessel within 3km of one of ANY target locations
 			disableOnStateChange = true
 			hideChildren = true
 			
@@ -341,92 +335,84 @@ CONTRACT_TYPE
 				name = ReachState
 				type = ReachState
 				targetBody = Moon
-				disableOnStateChange = true
 				situation = LANDED
 				hideChildren = true
 			}
-		}
-
-		
-		PARAMETER
-		{
-			title = Land within 3km of target locations
-			name = TargetedLandingOptional
-			type = Any
-			hideChildren = true
-			completeInSequence = true
-			
-			PARAMETER
-			{
-				name = Mare Tranquillitatis
-				type = VisitWaypoint
-				index = 0
-				distance = 3000.0
-				title = Land within 3km of @/String11
-				showMessages = true
-				disableOnStateChange = true
-				hideChildren = true
-			}
-			
-			PARAMETER
-			{
-				name = Oceanus Procellarum
-				type = VisitWaypoint
-				index = 1
-				distance = 3000.0
-				title = Land within 3km of @/String12
-				showMessages = true
-				disableOnStateChange = true
-				hideChildren = true
-			}
-			
-			PARAMETER
-			{
-				name = Fra Mauro
-				type = VisitWaypoint
-				index = 2
-				distance = 3000.0
-				title = Land within 3km of @/String14
-				showMessages = true
-				disableOnStateChange = true
-				hideChildren = true
-			}
-			
-			PARAMETER
-			{
-				name = Hadley-Apennines
-				type = VisitWaypoint
-				index = 3
-				distance = 3000.0
-				title = Land within 3km of @/String15
-				showMessages = true
-				disableOnStateChange = true
-				hideChildren = true
-			}
-			
-			PARAMETER
-			{
-				name = Descartes
-				type = VisitWaypoint
-				index = 4
-				distance = 3000.0
-				title = Land within 3km of @/String16
-				showMessages = true
-				disableOnStateChange = true
-				hideChildren = true
-			}
-			
-			PARAMETER
-			{
-				name = Taurus-Littrow
-				type = VisitWaypoint
-				index = 5
-				distance = 3000.0
-				title = Land within 3km of @/String17
-				showMessages = true
-				disableOnStateChange = true
-				hideChildren = true
-			}
+            
+            PARAMETER
+            {
+                title = Land within 3km of ANY target location
+                name = TargetedLandingOptional
+                type = Any
+                hideChildren = true
+                completeInSequence = true
+                
+                PARAMETER
+                {
+                    name = Mare Tranquillitatis
+                    type = VisitWaypoint
+                    index = 0
+                    distance = 3000.0
+                    title = Land within 3km of @/String11
+                    showMessages = true
+                    hideChildren = true
+                }
+                
+                PARAMETER
+                {
+                    name = Oceanus Procellarum
+                    type = VisitWaypoint
+                    index = 1
+                    distance = 3000.0
+                    title = Land within 3km of @/String12
+                    showMessages = true
+                    hideChildren = true
+                }
+                
+                PARAMETER
+                {
+                    name = Fra Mauro
+                    type = VisitWaypoint
+                    index = 2
+                    distance = 3000.0
+                    title = Land within 3km of @/String14
+                    showMessages = true
+                    hideChildren = true
+                }
+                
+                PARAMETER
+                {
+                    name = Hadley-Apennines
+                    type = VisitWaypoint
+                    index = 3
+                    distance = 3000.0
+                    title = Land within 3km of @/String15
+                    showMessages = true
+                    hideChildren = true
+                }
+                
+                PARAMETER
+                {
+                    name = Descartes
+                    type = VisitWaypoint
+                    index = 4
+                    distance = 3000.0
+                    title = Land within 3km of @/String16
+                    showMessages = true
+                    hideChildren = true
+                }
+                
+                PARAMETER
+                {
+                    name = Taurus-Littrow
+                    type = VisitWaypoint
+                    index = 5
+                    distance = 3000.0
+                    title = Land within 3km of @/String17
+                    showMessages = true
+                    hideChildren = true
+                }
+            }
 		}
 
 		PARAMETER


### PR DESCRIPTION
Current `Crewed Targeted Moon Landing` requires landing within 1km of target locations, which is very difficult due to in-game limitations, also also does not make sense that the entire mission becomes a failure if you miss the site by just 1km.

The modified version：
- Relax distance requirement 1km -> 10km for completion (updated)
- Bonus science if you land within 3km, which is roughly [how far off Apollo did historically](https://space.stackexchange.com/questions/37488/how-far-off-did-apollo-11-land)
- Total reputation is unchanged (25% moved from base to the optional part)
- Check waypoint distance and landing status concurrently to prevent cheesing it by landing and then fly-by the waypoints

Also fixing some texts along the way.