### PR TITLE
Stagger Chief Scientist unlocks

### DIFF
--- a/GameData/RP-1/Strategies/Leaders/LeadersScientists.cfg
+++ b/GameData/RP-1/Strategies/Leaders/LeadersScientists.cfg
@@ -24,8 +24,8 @@ STRATEGY
 	{
 		ANY
 		{
-			complete_contract = FirstScienceSat
-			complete_contract = FirstScienceSat-Heavy
+			complete_contract = SoundingRocketBio
+			complete_contract = SuborbitalReturn
 		}
 	}
 
@@ -202,8 +202,8 @@ STRATEGY
 	{
 		ANY
 		{
-			complete_contract = FirstScienceSat
-			complete_contract = FirstScienceSat-Heavy
+			complete_contract = SoundingRocketBio
+			complete_contract = SuborbitalReturn
 		}
 	}
 
@@ -270,8 +270,8 @@ STRATEGY
 	{
 		ANY
 		{
-			complete_contract = FirstScienceSat
-			complete_contract = FirstScienceSat-Heavy
+			complete_contract = SoundingRocketBio
+			complete_contract = SuborbitalReturn
 		}
 	}
 
@@ -406,8 +406,8 @@ STRATEGY
 	{
 		ANY
 		{
-			complete_contract = FirstScienceSat
-			complete_contract = FirstScienceSat-Heavy
+			complete_contract = SoundingRocketBio
+			complete_contract = SuborbitalReturn
 		}
 	}
 
@@ -605,7 +605,7 @@ STRATEGY
 	name = leaderLockedScientist
 	RP0conf = True
 	title = Launch a SciSat First
-	desc = Scientists will unlock once you complete either the First Scientific Satellite contract or the First Scientific Satellite (1000 kg) contract. 
+	desc = Some scientists will unlock once you complete the suborbital return or first low space biological experimentation contracts, and the rest after you complete either the First Scientific Satellite contract or the First Scientific Satellite (1000 kg) contract. 
 	department = Science
 	icon = RP-1/Strategies/Leaders/Padlock_ICON
 	iconDepartment = RP-1/Strategies/Leaders/EmptyLeader


### PR DESCRIPTION
Make the scientists that are relevant to the early game unlock a bit sooner. Half the scientists unlock after suborbital return/first bio now, with the rest still going off scisat