### PR TITLE
Remove downsides from subcontractors, buff research rate modifiers

### DIFF
--- a/GameData/RP-1/Strategies/Leaders/LeadersSubcontractors.cfg
+++ b/GameData/RP-1/Strategies/Leaders/LeadersSubcontractors.cfg
@@ -71,7 +71,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = Crewed Spaceflight Visionary
 		effectDescription = command module
-		multiplier = 1.05
+		multiplier = 1.15
 		nodeTypes
 		{
 			typeNode = Command
@@ -110,7 +110,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = Almaz and Salyut Stations
 		effectDescription = station
-		multiplier = 1.05
+		multiplier = 1.15
 		nodeTypes
 		{
 			typeNode = Stations
@@ -149,7 +149,7 @@ STRATEGY
 		name = ResearchRateModifier //TODO: should be a integration speed buff to staged combustion
 									//TODO: leaving this like this now until I can target SC parts
 		effectTitle = Jet Engine Proficiency
-		multiplier = 1.05
+		multiplier = 1.15
 		effectDescription = flight 
 		nodeTypes
 		{
@@ -189,7 +189,7 @@ STRATEGY
 		name = ResearchRateModifier
 		effectTitle = The Proton Engines
 		effectDescription = staged rocket engine
-		multiplier = 1.05
+		multiplier = 1.1
 		nodeTypes
 		{
 			typeNode = Staged
@@ -229,7 +229,7 @@ STRATEGY
 	{
 		name = ResearchRateModifier
 		effectTitle = Early Solid Rocket Pioneers
-		multiplier = 1.05
+		multiplier = 1.1
 		effectDescription = solid rocket engine 
 		nodeTypes
 		{
@@ -482,7 +482,7 @@ STRATEGY
 	{
 		name = ResearchRateModifier
 		effectTitle = US Foremost Engine Developer
-		multiplier = 1.05
+		multiplier = 1.1
 		effectDescription = early and orbital rocket engine
 		nodeTypes
 		{

--- a/GameData/RP-1/Strategies/Leaders/LeadersSubcontractors.cfg
+++ b/GameData/RP-1/Strategies/Leaders/LeadersSubcontractors.cfg
@@ -38,30 +38,6 @@ STRATEGY
 			item = SalaryResearchers
 		}
 	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = Shared Prestige
-		currency = Reputation
-		effectDescription = from contracts
-		multiplier = 0.95
-		transactionReasons
-		{
-			item = ContractReward
-		}
-	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = ОКБ Politics
-		currency = Confidence
-		effectDescription = from contracts
-		multiplier = 0.95
-		transactionReasons
-		{
-			item = ContractReward
-		}
-	}
 }
 
 STRATEGY
@@ -99,30 +75,6 @@ STRATEGY
 		nodeTypes
 		{
 			typeNode = Command
-		}
-	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = Shared Prestige
-		currency = Reputation
-		effectDescription = from contracts
-		multiplier = 0.95
-		transactionReasons
-		{
-			item = ContractReward
-		}
-	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = ОКБ Politics
-		currency = Confidence
-		effectDescription = from contracts
-		multiplier = 0.95
-		transactionReasons
-		{
-			item = ContractReward
 		}
 	}
 }
@@ -164,30 +116,6 @@ STRATEGY
 			typeNode = Stations
 		}
 	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = Shared Prestige
-		currency = Reputation
-		effectDescription = from contracts
-		multiplier = 0.95
-		transactionReasons
-		{
-			item = ContractReward
-		}
-	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = ОКБ Politics
-		currency = Confidence
-		effectDescription = from contracts
-		multiplier = 0.95
-		transactionReasons
-		{
-			item = ContractReward
-		}
-	}
 }
 
 STRATEGY
@@ -221,35 +149,11 @@ STRATEGY
 		name = ResearchRateModifier //TODO: should be a integration speed buff to staged combustion
 									//TODO: leaving this like this now until I can target SC parts
 		effectTitle = Jet Engine Proficiency
-		multiplier = 1.1
+		multiplier = 1.05
 		effectDescription = flight 
 		nodeTypes
 		{
 			typeNode = Flight
-		}
-	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = Shared Prestige
-		currency = Reputation
-		effectDescription = from contracts
-		multiplier = 0.9
-		transactionReasons
-		{
-			item = ContractReward
-		}
-	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = ОКБ Politics
-		currency = Confidence
-		effectDescription = from contracts
-		multiplier = 0.9
-		transactionReasons
-		{
-			item = ContractReward
 		}
 	}
 }
@@ -289,30 +193,6 @@ STRATEGY
 		nodeTypes
 		{
 			typeNode = Staged
-		}
-	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = Shared Prestige
-		currency = Reputation
-		effectDescription = from contracts
-		multiplier = 0.95
-		transactionReasons
-		{
-			item = ContractReward
-		}
-	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = ОКБ Politics
-		currency = Confidence
-		effectDescription = from contracts
-		multiplier = 0.95
-		transactionReasons
-		{
-			item = ContractReward
 		}
 	}
 }
@@ -356,18 +236,6 @@ STRATEGY
 			item = Solid
 		}
 	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = Hired Contractor
-		currency = Funds
-		effectDescription = from program funding
-		multiplier = 0.99
-		transactionReasons
-		{
-			item = ProgramFunding
-		}
-	}
 }
 
 STRATEGY
@@ -406,18 +274,6 @@ STRATEGY
 		tags
 		{
 			item = Nuclear
-		}
-	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = Hired Contractor
-		currency = Funds
-		effectDescription = from program funding
-		multiplier = 0.99
-		transactionReasons
-		{
-			item = ProgramFunding
 		}
 	}
 }
@@ -473,18 +329,6 @@ STRATEGY
 			item = RateAirlaunch
 		}
 	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = Hired Contractor
-		currency = Funds
-		effectDescription = from program funding
-		multiplier = 0.995
-		transactionReasons
-		{
-			item = ProgramFunding
-		}
-	}
 }
 
 STRATEGY
@@ -525,18 +369,6 @@ STRATEGY
 			item = Cockpit
 		}
 	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = Hired Contractor
-		currency = Funds
-		effectDescription = from program funding
-		multiplier = 0.99
-		transactionReasons
-		{
-			item = ProgramFunding
-		}
-	}
 }
 
 STRATEGY
@@ -575,18 +407,6 @@ STRATEGY
 		tags
 		{
 			item = TankIsogrid
-		}
-	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = Hired Contractor
-		currency = Funds
-		effectDescription = from program funding
-		multiplier = 0.99
-		transactionReasons
-		{
-			item = ProgramFunding
 		}
 	}
 }
@@ -630,18 +450,6 @@ STRATEGY
 			item = Avionics
 		}
 	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = Hired Contractor
-		currency = Funds
-		effectDescription = from program funding
-		multiplier = 0.99
-		transactionReasons
-		{
-			item = ProgramFunding
-		}
-	}
 }
 
 STRATEGY
@@ -679,18 +487,6 @@ STRATEGY
 		nodeTypes
 		{
 			typeNode = RocketEngines
-		}
-	}
-	EFFECT
-	{
-		name = CurrencyModifier
-		effectTitle = Hired Contractor
-		currency = Funds
-		effectDescription = from program funding
-		multiplier = 0.99
-		transactionReasons
-		{
-			item = ProgramFunding
 		}
 	}
 }


### PR DESCRIPTION
Players will still have to pick carefully due to only having two subcontractor slots, but this removes the downsides from these less influential leaders, and should hopefully make the capitalist ones more practical. Feedback welcome