### PR TITLE
Enforce body restrictions for crewed experiments

### DIFF
--- a/GameData/RP-1/Science/Experiments/CrewScience/BasicCapsuleExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/BasicCapsuleExperiments.cfg
@@ -36,8 +36,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
-            // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
-	      BodyAllowed = HomeBody
+        // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
 		IncludeExperiment = 
  	}
 }
@@ -87,8 +87,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
-	      // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
-	      BodyAllowed = HomeBody
+	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
 		IncludeExperiment = 
  	}
 }
@@ -138,8 +138,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
-	      // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
-	      BodyAllowed = HomeBody
+	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -189,8 +189,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0.002
-	      // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
-	      BodyAllowed = HomeBody
+	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }

--- a/GameData/RP-1/Science/Experiments/CrewScience/MatureCapsuleExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/MatureCapsuleExperiments.cfg
@@ -37,6 +37,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBodyAndMoons
 		IncludeExperiment = 
   	}
 }
@@ -86,6 +88,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -135,6 +139,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -184,6 +190,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0.0001
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -195,7 +203,7 @@ EXPERIMENT_DEFINITION
 		experiment_id = RP0TerrainPhotography
 		ec_rate = 0
 		data_rate = 50
-		@data_rate /= 129600 // 3 days
+		@data_rate /= 129600 // 1.5 days
 		%sample_amount = 1
             @sample_amount /= 3
 		requires = CrewMin:2
@@ -235,6 +243,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0.0001
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -246,7 +256,7 @@ EXPERIMENT_DEFINITION
 		experiment_id = RP0WeatherPhotography
 		ec_rate = 0
 		data_rate = 50
-		@data_rate /= 129600 // 3 days
+		@data_rate /= 129600 // 1.5 days
 		%sample_amount = 1
             @sample_amount /= 3
 		requires = CrewMin:2

--- a/GameData/RP-1/Science/Experiments/CrewScience/SecondGenExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/SecondGenExperiments.cfg
@@ -36,8 +36,8 @@ EXPERIMENT_DEFINITION
   	{
   		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
-	      // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
-	      BodyAllowed = HomeBody
+	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -87,6 +87,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBodyAndMoons
 		IncludeExperiment = 
   	}
 }
@@ -136,6 +138,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBodyAndMoons
 		IncludeExperiment = 
   	}
 }
@@ -185,8 +189,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
-	      // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
-	      BodyAllowed = HomeBody
+	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -236,8 +240,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0.0005
-  	      // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
-	      BodyAllowed = HomeBody
+  	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -288,6 +292,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0.0005
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBodyAndMoons
 		IncludeExperiment = 
   	}
 }
@@ -338,8 +344,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
-	      // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
-	      BodyAllowed = HomeBody
+	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -389,8 +395,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
-	      // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
-	      BodyAllowed = HomeBody
+	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -440,8 +446,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
-	      // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
-	      BodyAllowed = HomeBody
+	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -491,6 +497,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBodyAndMoons
 		IncludeExperiment = 
   	}
 }
@@ -540,8 +548,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0.004
-	      // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
-	      BodyAllowed = HomeBody
+	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -592,8 +600,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
-	      // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
-	      BodyAllowed = HomeBody
+	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }

--- a/GameData/RP-1/Science/Experiments/CrewScience/StationExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/StationExperiments.cfg
@@ -42,6 +42,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -88,6 +90,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -135,6 +139,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -182,6 +188,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0 //Placeholder
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -230,6 +238,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -277,6 +287,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -324,6 +336,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0.0272 //7 days of input to stay mass neutral
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -372,6 +386,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0 //Placeholder
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -424,6 +440,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = RP0longDurationHabit1
   	}
 }
@@ -471,6 +489,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -518,6 +538,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -565,6 +587,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -612,6 +636,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -659,6 +685,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0.005 //Placeholder
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -707,6 +735,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0 //Placeholder
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -754,6 +784,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0 //Placeholder
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -801,6 +833,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0 //Placeholder
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -848,6 +882,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0 //Placeholder
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -895,6 +931,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0.05 //Placeholder
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -943,6 +981,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0.005 //Placeholder
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }
@@ -991,6 +1031,8 @@ EXPERIMENT_DEFINITION
   	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0 //Placeholder
+		// Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+		BodyAllowed = HomeBody
 		IncludeExperiment = 
   	}
 }


### PR DESCRIPTION
Solves #2416.
Added `BodyAllowed = HomeBody` for experiments with `celestialBodies = Earth`, and added `BodyAllowed = HomeBodyAndMoons` for experiments with `celestialBodies = Earth;Moon`. 
Also trimmed the whitespace.