### PR TITLE
Adjust MG01 to match historical mass and power consumption values

### DIFF
--- a/GameData/RP-1/Parts/Science/MAGNET01-EarlyMagnet.cfg
+++ b/GameData/RP-1/Parts/Science/MAGNET01-EarlyMagnet.cfg
@@ -36,7 +36,7 @@ PART
 	manufacturer = Coatl Aerospace
 	description = Mounted at the end of this folding boom is the early magnetometer, used to measure magnetic fields. Though these fields stretch out into space, their study can hint at a planet's core. Experiments like these are also used to study the Sun's magnetic field and how it interacts with planets. Historically, this experiment is based on the ones flown on many early satellite and probe missions.
 
-	mass = 0.015
+	mass = 0.00177
 	bulkheadProfiles = size0, srf
 	crashTolerance = 9
 	maxTemp = 1200

--- a/GameData/RP-1/Science/Configure.cfg
+++ b/GameData/RP-1/Science/Configure.cfg
@@ -270,7 +270,7 @@
 		{
 			name = Magnetometer 1
 			mass = 0.00177
-			cost = 83
+			cost = 33
 			tech = scienceSatellite
 			
 			MODULE

--- a/GameData/RP-1/Science/Configure.cfg
+++ b/GameData/RP-1/Science/Configure.cfg
@@ -269,7 +269,7 @@
 		SETUP
 		{
 			name = Magnetometer 1
-			mass = 0.015
+			mass = 0.00177
 			cost = 83
 			tech = scienceSatellite
 			

--- a/GameData/RP-1/Science/Experiments/MagneticScan.cfg
+++ b/GameData/RP-1/Science/Experiments/MagneticScan.cfg
@@ -50,7 +50,7 @@ EXPERIMENT_DEFINITION
 {
 	@MODULE[Experiment]:HAS[#experiment_id[RP0magScan1]]
 	{
-		%ec_rate = 0.006
+		%ec_rate = 0.000206
 		%data_rate = 2.6208 //1 byte/s
 		@data_rate /= 2620800 //1 month
 		%requires = 
@@ -208,7 +208,8 @@ EXPERIMENT_DEFINITION
 
 //	LEVEL 1
 //	Early Magnetometer Boom
-//	Based on the instrument flown on many early missions
+//	Based on the instrument flown on Explorer VI and many other missions
+//	https://www.sdfo.org/stl/Explorer6/pdfs/59%20STL%20Explorer%20VI%20Experiments.pdf
 //	Part: Coatl Vorona
 //====================================================================================
 


### PR DESCRIPTION
Currently Magnetic Scan 1 consumes 6W and weighs 15kg. This is siginficantly higher than actual values on spacecraft like Explorer VI (which has instrument heritage from Pioneer 0-2), where the entire magnetometry part of the spacecraft weighed 1.77kg and consumed 206 mW. This PR adjusts the first magnetometer to use the values of Explorer VI, which flew on 1959-08-07.

Source:
Space Technology Laboratories Explorer VI Experiments: https://www.sdfo.org/stl/Explorer6/pdfs/59%20STL%20Explorer%20VI%20Experiments.pdf
Also archived on the RP-1 Discord: https://discord.com/channels/319857228905447436/541475381157298177/1298251183022018612

And source on this being the company that manufactured these devices:
Page 299 of https://ntrs.nasa.gov/api/citations/19650012364/downloads/19650012364.pdf
