### PR TITLE
Increase High Alt Flight experiment reward to account for body modifier

### DIFF
--- a/GameData/RP-1/Science/Experiments/CrewScience/CockpitExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/CockpitExperiments.cfg
@@ -113,8 +113,8 @@ EXPERIMENT_DEFINITION
 {
     id = RP0SupersonicHigh1
     title = High altitude flight
-    baseValue = 16
-    scienceCap = 16
+    baseValue = 25  // Actually awards 15 points due to 0.6x body modifier
+    scienceCap = 25
     dataScale = 0.02
     situationMask = 8
     biomeMask = 0


### PR DESCRIPTION
As of now, the high-altitude flight experiment awards 9.6 science points. This number seems dubious, since 1) the other three cockpit experiments award integer numbers of science points and 2) the Ma1.5 experiment awards 9 points while being much easier than the high-altitude flight experiment. I suspect this is an oversight, as Earth Flying Low has a body modifier of x1, but Earth Flying High has x0.6. If a person wants to award 16 points for high-altitude flight and naively enters the number in the config, only 9.6 points are awarded. There are at least two instances of a dev forgetting the body modifier: 3e1d9194520bae61f2f58f6482478715305596af (6+10+12+15 = 43, whereas hypersonic flight requires 1+4+4+12 = 21) and 2ad5d1bdb5f0f5c8f5efc6ac695eada3527bf20b (if the dev remembered, he should change the experiment value as well). 
Here, I set the base value in the config to 25, so that 15 points are awarded. This is one less than the dev "intended," but 25 and 15 are both integers. 