### PR TITLE
Remove payloads from SM tanks again

### DIFF
--- a/GameData/RP-1/Contracts/RP0_Contract_Resources.cfg
+++ b/GameData/RP-1/Contracts/RP0_Contract_Resources.cfg
@@ -99,38 +99,6 @@ RESOURCE_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 	}
-	TANK
-	{
-		name = ComSatPayload
-		utilization = 1
-		fillable = True
-		amount = 0.0
-		maxAmount = 0.0
-	}
-	TANK
-	{
-		name = WeatherSatPayload
-		utilization = 1
-		fillable = True
-		amount = 0.0
-		maxAmount = 0.0
-	}
-	TANK
-	{
-		name = NavSatPayload
-		utilization = 1
-		fillable = True
-		amount = 0.0
-		maxAmount = 0.0
-	}
-	TANK
-	{
-		name = SoundingPayload
-		utilization = 1
-		fillable = True
-		amount = 0.0
-		maxAmount = 0.0
-	}
 }
 
 @TANK_DEFINITION:HAS[#addSoundingPayload[true]]:FOR[RP-0]


### PR DESCRIPTION
The space stations program PR #2326 accidentally added ComSat, NavSat and WeatherSat payloads back to SM tanks. Putting SoundingPayload into SM tanks is a classic "noob trap"; you should always put it into HP regular tanks, instead. Remove all these payload resources from SM tanks again.