### PR TITLE
Add optional reward to docking contract for rendezvousing with a different craft first

### DIFF
--- a/GameData/RP-1/Contracts/Earth Crewed Adv/Docking.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed Adv/Docking.cfg
@@ -80,6 +80,37 @@ CONTRACT_TYPE
 		tag = CrewedOrbitOptional
 		invertRequirement = true
 		title = Don't have an active optional crewed orbit contract.
+  	}
+
+	PARAMETER
+	{
+		name = Rendezvous
+		type = VesselParameterGroup
+		title = OPTIONAL: Rendezvous with a craft already in orbit
+		define = Rendezvous
+		optional = true
+		rewardReputation = Round(@rewardReputation * 0.3 + 0.4999, 1)
+
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minPeA = @targetBody.AtmosphereAltitude()
+			title = Orbit @targetBody
+			disableOnStateChange = true
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Rendezvous
+			type = RP1Rendezvous
+			distance = 100
+			relativeSpeed = 0.5
+			title = Rendezvous two craft in orbit (closer than 100m, relative speed less than 0.5m/s)
+			hideChildren = true
+			disableOnStateChange = true
+		}
+	}
 	}
 
 	PARAMETER

--- a/GameData/RP-1/Contracts/Earth Crewed Adv/Docking.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed Adv/Docking.cfg
@@ -89,7 +89,7 @@ CONTRACT_TYPE
 		title = OPTIONAL: Rendezvous with a craft already in orbit
 		define = Rendezvous
 		optional = true
-		rewardReputation = Round(@rewardReputation * 0.3 + 0.4999, 1)
+		rewardReputation = Round(@/rewardReputation * 0.3 + 0.4999, 1)
 
 		PARAMETER
 		{

--- a/GameData/RP-1/Contracts/Earth Crewed Adv/Docking.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed Adv/Docking.cfg
@@ -96,6 +96,15 @@ CONTRACT_TYPE
 			title = Launch a new vessel
 			hideChildren = true
 		}
+  		PARAMETER
+		{
+			name = HasCrew
+			type = HasCrew
+			minCrew = 1
+			crewOnly = true
+			title = Have at least 1 crewmember on board
+			hideChildren = true
+		}
 		PARAMETER
 		{
 			name = Orbit
@@ -110,6 +119,14 @@ CONTRACT_TYPE
 			name = Docking
 			type = Docking
 			title = Dock two spacecraft in orbit
+			hideChildren = true
+			completeInSequence = true
+		}
+  		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return home safely
 			hideChildren = true
 			completeInSequence = true
 		}

--- a/GameData/RP-1/Contracts/Earth Crewed Adv/Docking.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed Adv/Docking.cfg
@@ -111,7 +111,6 @@ CONTRACT_TYPE
 			disableOnStateChange = true
 		}
 	}
-	}
 
 	PARAMETER
 	{

--- a/GameData/RP-1/Contracts/Earth Crewed Adv/Docking.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed Adv/Docking.cfg
@@ -116,7 +116,7 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Dock to another spacecraft while in orbit.
+		title = Dock to another spacecraft while in orbit. // does not require crew because of Kosmos 186 and 188 docking autonomously in 1967
 		define = dockingSpacecraft
 
 		PARAMETER
@@ -124,15 +124,6 @@ CONTRACT_TYPE
 			name = NewVessel
 			type = NewVessel
 			title = Launch a new vessel
-			hideChildren = true
-		}
-  		PARAMETER
-		{
-			name = HasCrew
-			type = HasCrew
-			minCrew = 1
-			crewOnly = true
-			title = Have at least 1 crewmember on board
 			hideChildren = true
 		}
 		PARAMETER
@@ -149,14 +140,6 @@ CONTRACT_TYPE
 			name = Docking
 			type = Docking
 			title = Dock two spacecraft in orbit
-			hideChildren = true
-			completeInSequence = true
-		}
-  		PARAMETER
-		{
-			name = ReturnHome
-			type = RP1ReturnHome
-			title = Return home safely
 			hideChildren = true
 			completeInSequence = true
 		}


### PR DESCRIPTION
~~As per discussion in https://discord.com/channels/319857228905447436/1295137142762242139/1328487821220118682~~
Additionally, add extra reputation/confidence for rendezvousing with a different craft before docking (instead of just re-docking to your upper stage, for example)