### PR TITLE
Rename modular RCS to procedural RCS

### DIFF
--- a/Source/Tech Tree/Parts Browser/data/ROEngines.json
+++ b/Source/Tech Tree/Parts Browser/data/ROEngines.json
@@ -4427,7 +4427,7 @@
     },
     {
         "name": "ROE-ModularRCS",
-        "title": "Modular RCS",
+        "title": "Procedural RCS",
         "description": "",
         "mod": "ROEngines",
         "cost": 2,


### PR DESCRIPTION
To make it line up with all other scalable parts in Procedural Tanks, and because the word "modular" doesn't really fit here (it's not a module of anything, and it's not a part that would snap to others of the same part somehow)

Should be done with https://github.com/KSP-RO/ROEngines/pull/254