### PR TITLE
Add Community Tech Tree to conflicts

### DIFF
--- a/RP-1.netkan
+++ b/RP-1.netkan
@@ -112,6 +112,7 @@ conflicts:
   - name: KerbalConstructionTime
   - name: CrowdSourcedScience
   - name: HideEmptyTechNodes
+  - name: CommunityTechTree
   - name: MechJebForAll
   - name: NearFutureElectrical-DecayingRTGs
   - name: KRASH


### PR DESCRIPTION
There are a fair amount of other potentially conflicting tech trees on ckan that might be worthwhile to add to conflicts, but community tech tree is the biggest one by far (nearly 1.1 million downloads) and it is recommended by the near future mods, most of which are suggested by RP-1.