### PR TITLE
Change the default name of the first launchpad from "Launch Complex #-A" to "LaunchPad 1"

### DIFF
--- a/Source/RP0/SpaceCenter/LaunchComplex/LaunchComplex.cs
+++ b/Source/RP0/SpaceCenter/LaunchComplex/LaunchComplex.cs
@@ -162,7 +162,7 @@ namespace RP0
             if (_lcData.lcType == LaunchComplexType.Pad)
             {
                 float fracLevel = _lcData.GetPadFracLevel();
-                var pad = new LCLaunchPad(Guid.NewGuid(), Name + "-A", fracLevel);
+                var pad = new LCLaunchPad(Guid.NewGuid(), "LaunchPad 1", fracLevel);
                 pad.isOperational = true;
                 LaunchPads.Add(pad);
             }


### PR DESCRIPTION
When making a new launch complex, RP-1 automatically creates a launch pad with the name of "Launch Complex [number]-A". Not only is this only slightly different from the name of the Launch Complex itself (making it difficult for new players to tell the difference), it is also inconsistent with the default name of new launchpads created for that complex. There is also no real need for the player to be able to tell which launchpads are accessible to which complexes at a glance, as you can only access a launchpad from a certain complex.
For example, without changing the name of anything, here is what happens when you make 3 launch pads for LC-1.

Launch Complex 1: (default names)
Launch Complex 1-A
LaunchPad 2
LaunchPad 3

![image](https://github.com/user-attachments/assets/5340b345-4ff3-4e8b-9723-234a5db5e3f1)

This PR fixes this inconsistency and fixes https://github.com/KSP-RO/RP-1/issues/2334.