### PR TITLE
Fix a timewarp kraken, add MNA and ArgPe to simulation GUI options, and some other various simulation GUI changes

### DIFF
--- a/Source/RP0/SpaceCenter/SimulationParams.cs
+++ b/Source/RP0/SpaceCenter/SimulationParams.cs
@@ -32,7 +32,7 @@ namespace RP0
         public bool SimulateInOrbit, DisableFailures;
         public bool IsVesselMoved;
         [Persistent]
-        public double SimulationUT, SimOrbitAltitude, SimOrbitPe, SimOrbitAp, SimInclination, SimLAN;
+        public double SimulationUT, SimOrbitAltitude, SimOrbitPe, SimOrbitAp, SimInclination, SimLAN, SimMNA, SimArgPE;
         [Persistent]
         public int DelayMoveSeconds;
 

--- a/Source/RP0/SpaceCenter/SimulationParams.cs
+++ b/Source/RP0/SpaceCenter/SimulationParams.cs
@@ -32,7 +32,7 @@ namespace RP0
         public bool SimulateInOrbit, DisableFailures;
         public bool IsVesselMoved;
         [Persistent]
-        public double SimulationUT, SimOrbitAltitude, SimOrbitPe, SimOrbitAp, SimInclination, SimLAN, SimMNA, SimArgPE;
+        public double SimulationUT, SimOrbitAltitude, SimOrbitPe, SimOrbitAp, SimInclination, SimLAN, SimMNA, SimArgPe;
         [Persistent]
         public int DelayMoveSeconds;
 

--- a/Source/RP0/SpaceCenter/SpaceCenterManagement.cs
+++ b/Source/RP0/SpaceCenter/SpaceCenterManagement.cs
@@ -1301,7 +1301,7 @@ namespace RP0
                 double sma = simParams.SimOrbitAltitude + body.Radius;
                 double ecc = 0.0000001;    // Just a really smol value to prevent Ap and Pe from flickering around
                 RP0Debug.Log($"Moving vessel to orbit. {body.bodyName}:{simParams.SimOrbitAltitude}:{simParams.SimInclination}");
-                FlightGlobals.fetch.SetShipOrbit(body.flightGlobalsIndex, ecc, sma, simParams.SimInclination, simParams.SimLAN, 0.0, 0.0, 0.0);
+                FlightGlobals.fetch.SetShipOrbit(body.flightGlobalsIndex, ecc, sma, simParams.SimInclination, simParams.SimLAN, simParams.SimMNA, simParams.SimArgPe, 0.0); // selBodyIndex, ecc, sma, inc, LAN, mna, argPe, ObT
                 FloatingOrigin.ResetTerrainShaderOffset();
             }
             else
@@ -1311,7 +1311,7 @@ namespace RP0
                 double sma = (ra + rp) / 2;
                 double ecc = (ra - rp) / (ra + rp);
                 RP0Debug.Log($"Moving vessel to orbit. {body.bodyName}:{simParams.SimOrbitPe}/{simParams.SimOrbitAp}:{simParams.SimInclination}");
-                FlightGlobals.fetch.SetShipOrbit(body.flightGlobalsIndex, ecc, sma, simParams.SimInclination, simParams.SimLAN, Math.PI, 0.0, 0.0);
+                FlightGlobals.fetch.SetShipOrbit(body.flightGlobalsIndex, ecc, sma, simParams.SimInclination, simParams.SimLAN, simParams.SimMNA, simParams.SimArgPe, 0.0); // selBodyIndex, ecc, sma, inc, LAN, mna, argPe, ObT
                 FloatingOrigin.ResetTerrainShaderOffset();
             }
         }

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -10,7 +10,7 @@ namespace RP0
         private static Rect _simulationConfigPosition = new Rect((Screen.width / 2) - 150, (Screen.height / 4), 300, 1);
         private static Vector2 _bodyChooserScrollPos;
 
-        private static string _sOrbitAlt = "", _sOrbitPe = "", _sOrbitAp = "", _sOrbitInc = "", _sOrbitLAN = "", _UTString = "", _sDelay = "0";
+        private static string _sOrbitAlt = "", _sOrbitPe = "", _sOrbitAp = "", _sOrbitInc = "", _sOrbitLAN = "", _sOrbitMNA = "", _sOrbitArgPE = "", _UTString = "", _sDelay = "0";
         private static bool _fromCurrentUT = true;
         private static bool _circOrbit = true;
 
@@ -121,6 +121,16 @@ namespace RP0
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("LAN: ");
                 _sOrbitLAN = GUILayout.TextField(_sOrbitLAN, GUILayout.Width(50));
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("Mean Anomaly: ");
+                _sOrbitMNA = GUILayout.TextField(_sOrbitMNA, GUILayout.Width(50));
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("Argument of Periapsis: ");
+                _sOrbitArgPE = GUILayout.TextField(_sOrbitArgPE, GUILayout.Width(50));
                 GUILayout.EndHorizontal();
             }
 
@@ -241,6 +251,16 @@ namespace RP0
                     simParams.SimLAN = 0;
                 else
                     simParams.SimLAN %= 360;
+
+                if (!double.TryParse(_sOrbitMNA, out simParams.SimMNA))
+                    simParams.SimMNA = Math.PI; // this will set it at apoapsis, good for safety
+                else
+                    simParams.SimMNA %= 2 * Math.PI;
+
+                if (!double.TryParse(_sOrbitArgPE, out simParams.SimArgPE))
+                    simParams.SimArgPE = 0;
+                else
+                    simParams.SimArgPE %= 360;
             }
 
             double currentUT = Planetarium.GetUniversalTime();

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -272,8 +272,8 @@ namespace RP0
                 return;
             }
             else if (!string.IsNullOrWhiteSpace(_UTString) && 
-                     (_UTString.Contains(":") && !System.Text.RegularExpressions.Regex.IsMatch(_UTString, @"^\d{4}-\d{2}-\d{2}")) ||
-                     !ROUtils.DTUtils.TryParseTimeString(_UTString, isTimespan: !_fromCurrentUT, out ut)) // if string is not empty and ((string has HH:mm but no YYYY-MM-DD) or (string fails TryParseTimeString)), then output failure
+                     ((_UTString.Contains(":") && !System.Text.RegularExpressions.Regex.IsMatch(_UTString, @"^\d{4}-\d{2}-\d{2}")) || 
+                      !ROUtils.DTUtils.TryParseTimeString(_UTString, isTimespan: !_fromCurrentUT, out ut))) // if string is not empty and ((string has HH:mm but no YYYY-MM-DD) or (string fails TryParseTimeString)), then output failure
             {
                 var message = new ScreenMessage("Please enter a valid time value.", 6f, ScreenMessageStyle.UPPER_CENTER);
                 ScreenMessages.PostScreenMessage(message);

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -238,7 +238,10 @@ namespace RP0
 
             double currentUT = Planetarium.GetUniversalTime();
             double ut = 0;
-            if (!string.IsNullOrWhiteSpace(_UTString) && !ROUtils.DTUtils.TryParseTimeString(_UTString, isTimespan: !_fromCurrentUT, out ut))
+            // if string is not empty and ((string has HH:mm but no YYYY-MM-DD) or (string fails TryParseTimeString)), then output failure
+            if (!string.IsNullOrWhiteSpace(_UTString) && 
+                (_UTString.Contains(":") && !System.Text.RegularExpressions.Regex.IsMatch(_UTString, @"^\d{4}-\d{2}-\d{2}")) ||
+                !ROUtils.DTUtils.TryParseTimeString(_UTString, isTimespan: !_fromCurrentUT, out ut))
             {
                 var message = new ScreenMessage("Please enter a valid time value.", 6f, ScreenMessageStyle.UPPER_CENTER);
                 ScreenMessages.PostScreenMessage(message);

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -138,7 +138,7 @@ namespace RP0
             GUILayout.BeginHorizontal();
             GUILayout.Label("Time: ");
             _UTString = GUILayout.TextField(_UTString, GUILayout.Width(110));
-            _fromCurrentUT = GUILayout.Toggle(_fromCurrentUT, new GUIContent(" From Now", "If selected the game will warp forwards by the amount of time entered onto the field. Otherwise the date and time will be set to entered value."));
+            _fromCurrentUT = GUILayout.Toggle(_fromCurrentUT, new GUIContent(" From Now", "If selected the game will warp forwards by the entered value. Otherwise the date and time will be set to the entered value."));
             GUILayout.EndHorizontal();
             if (_fromCurrentUT)
             {

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -135,7 +135,7 @@ namespace RP0
 
             if (ModUtils.IsTestFlightInstalled || ModUtils.IsTestLiteInstalled)
             {
-                simParams.DisableFailures = !GUILayout.Toggle(!simParams.DisableFailures, " Enable Part Failures");
+                simParams.DisableFailures = !GUILayout.Toggle(!simParams.DisableFailures, " Enable Part Failures with TestFlight or TestLite");
                 GUILayout.Space(4);
             }
 

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -324,7 +324,7 @@ namespace RP0
 
         private static double GetDefaultAltitudeForBody(CelestialBody body)
         {
-            return body.atmosphere ? body.atmosphereDepth + 20000 : 20000;
+            return body.atmosphere ? body.atmosphereDepth + 20010 : 20000;
         }
     }
 }

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -130,7 +130,7 @@ namespace RP0
             _UTString = GUILayout.TextField(_UTString, GUILayout.Width(110));
             _fromCurrentUT = GUILayout.Toggle(_fromCurrentUT, new GUIContent(" From Now", "If selected the game will warp forwards by the amount of time entered onto the field. Otherwise the date and time will be set to entered value."));
             GUILayout.EndHorizontal();
-            GUILayout.Label("Accepts values with format \"1y 2d 3h 4m 5s\" or \"1960-12-31 23:59\"");
+            GUILayout.Label("Accepts values with format \"1y 2d 3h 4m 5s\" or \"1960-12-31 23:59:59\"");
             GUILayout.Space(4);
 
             if (ModUtils.IsTestFlightInstalled || ModUtils.IsTestLiteInstalled)

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -138,7 +138,7 @@ namespace RP0
             GUILayout.BeginHorizontal();
             GUILayout.Label("Time: ");
             _UTString = GUILayout.TextField(_UTString, GUILayout.Width(110));
-            _fromCurrentUT = GUILayout.Toggle(_fromCurrentUT, new GUIContent(" From Now", "If selected the game will warp forwards by the entered value. Otherwise the date and time will be set to the entered value."), GUILayout.Width(300));
+            _fromCurrentUT = GUILayout.Toggle(_fromCurrentUT, new GUIContent(" From Now", "If selected the game will warp forwards by the entered value. Otherwise the date and time will be set to the entered value."));
             GUILayout.EndHorizontal();
             if (_fromCurrentUT)
             {

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -10,7 +10,7 @@ namespace RP0
         private static Rect _simulationConfigPosition = new Rect((Screen.width / 2) - 150, (Screen.height / 4), 300, 1);
         private static Vector2 _bodyChooserScrollPos;
 
-        private static string _sOrbitAlt = "", _sOrbitPe = "", _sOrbitAp = "", _sOrbitInc = "", _sOrbitLAN = "", _sOrbitMNA = "", _sOrbitArgPE = "", _UTString = "", _sDelay = "0";
+        private static string _sOrbitAlt = "", _sOrbitPe = "", _sOrbitAp = "", _sOrbitInc = "", _sOrbitLAN = "", _sOrbitMNA = "", _sOrbitArgPe = "", _UTString = "", _sDelay = "0";
         private static bool _fromCurrentUT = true;
         private static bool _circOrbit = true;
 
@@ -130,7 +130,7 @@ namespace RP0
 
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Argument of Periapsis: ");
-                _sOrbitArgPE = GUILayout.TextField(_sOrbitArgPE, GUILayout.Width(50));
+                _sOrbitArgPe = GUILayout.TextField(_sOrbitArgPe, GUILayout.Width(50));
                 GUILayout.EndHorizontal();
             }
 
@@ -257,10 +257,10 @@ namespace RP0
                 else
                     simParams.SimMNA %= 2 * Math.PI;
 
-                if (!double.TryParse(_sOrbitArgPE, out simParams.SimArgPE))
-                    simParams.SimArgPE = 0;
+                if (!double.TryParse(_sOrbitArgPe, out simParams.SimArgPe))
+                    simParams.SimArgPe = 0;
                 else
-                    simParams.SimArgPE %= 360;
+                    simParams.SimArgPe %= 360;
             }
 
             double currentUT = Planetarium.GetUniversalTime();

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -130,7 +130,7 @@ namespace RP0
             _UTString = GUILayout.TextField(_UTString, GUILayout.Width(110));
             _fromCurrentUT = GUILayout.Toggle(_fromCurrentUT, new GUIContent(" From Now", "If selected the game will warp forwards by the amount of time entered onto the field. Otherwise the date and time will be set to entered value."));
             GUILayout.EndHorizontal();
-            GUILayout.Label("Accepts values with format \"1y 2d 3h 4m 5s\" or \"1960-12-31 23:59:59\"");
+            GUILayout.Label("Accepts values with format \"1y 2d 3h 4m 5s\", \"1960-12-31 23:59:59\", or \"61883248319\".");
             GUILayout.Space(4);
 
             if (ModUtils.IsTestFlightInstalled || ModUtils.IsTestLiteInstalled)

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -87,8 +87,8 @@ namespace RP0
                     _sOrbitAlt = GUILayout.TextField(_sOrbitAlt, GUILayout.Width(100));
                     GUILayout.EndHorizontal();
                     GUILayout.BeginHorizontal();
-                    GUILayout.Label("Min: " + simParams.SimulationBody.atmosphereDepth / 1000);
-                    GUILayout.Label("Max: " + Math.Floor((simParams.SimulationBody.sphereOfInfluence - simParams.SimulationBody.Radius) / 1000));
+                    GUILayout.Label("Min: " + simParams.SimulationBody.atmosphereDepth / 1000 + "km");
+                    GUILayout.Label("Max: " + Math.Floor((simParams.SimulationBody.sphereOfInfluence - simParams.SimulationBody.Radius) / 1000) + "km");
                     GUILayout.EndHorizontal();
                 }
                 else
@@ -109,7 +109,7 @@ namespace RP0
             if (simParams.SimulateInOrbit)
             {
                 GUILayout.BeginHorizontal();
-                GUILayout.Label("Delay: (s)");
+                GUILayout.Label("Delay (s): ");
                 _sDelay = GUILayout.TextField(_sDelay, 3, GUILayout.Width(40));
                 GUILayout.EndHorizontal();
 

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -259,7 +259,6 @@ namespace RP0
                 ScreenMessages.PostScreenMessage(message);
                 return;
             }
-            
             simParams.DelayMoveSeconds = 0;
             if (_fromCurrentUT)
             {

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -130,7 +130,7 @@ namespace RP0
             _UTString = GUILayout.TextField(_UTString, GUILayout.Width(110));
             _fromCurrentUT = GUILayout.Toggle(_fromCurrentUT, new GUIContent(" From Now", "If selected the game will warp forwards by the amount of time entered onto the field. Otherwise the date and time will be set to entered value."));
             GUILayout.EndHorizontal();
-            GUILayout.Label("Accepts values with format \"1y 2d 3h 4m 5s\", \"1960-12-31 23:59:59\", or \"61883248319\".");
+            GUILayout.Label("Accepts values with formats \"1y 2d 3h 4m 5s\", \"1960-12-31 23:59:59\", or \"61883248319\".");
             GUILayout.Space(4);
 
             if (ModUtils.IsTestFlightInstalled || ModUtils.IsTestLiteInstalled)

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -138,7 +138,7 @@ namespace RP0
             GUILayout.BeginHorizontal();
             GUILayout.Label("Time: ");
             _UTString = GUILayout.TextField(_UTString, GUILayout.Width(110));
-            _fromCurrentUT = GUILayout.Toggle(_fromCurrentUT, new GUIContent(" From Now", "If selected the game will warp forwards by the entered value. Otherwise the date and time will be set to the entered value."));
+            _fromCurrentUT = GUILayout.Toggle(_fromCurrentUT, new GUIContent(" From Now", "If selected the game will warp forwards by the entered value. Otherwise the date and time will be set to the entered value."), GUILayout.Width(300));
             GUILayout.EndHorizontal();
             if (_fromCurrentUT)
             {

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -344,7 +344,7 @@ namespace RP0
 
         private static double GetDefaultAltitudeForBody(CelestialBody body)
         {
-            return body.atmosphere ? body.atmosphereDepth + 20010 : 20000;
+            return body.atmosphere ? body.atmosphereDepth + 5000 : 20000;
         }
     }
 }

--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -79,7 +79,7 @@ namespace RP0
             }
             if (simParams.SimulationBody != Planetarium.fetch.Home || simParams.SimulateInOrbit)
             {
-                _circOrbit = GUILayout.Toggle(_circOrbit, "Circular");
+                _circOrbit = GUILayout.Toggle(_circOrbit, " Circular");
                 if (_circOrbit)
                 {
                     GUILayout.BeginHorizontal();
@@ -114,22 +114,22 @@ namespace RP0
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label("Inclination: ");
+                GUILayout.Label("Inclination (degrees): ");
                 _sOrbitInc = GUILayout.TextField(_sOrbitInc, GUILayout.Width(50));
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label("LAN: ");
+                GUILayout.Label("LAN (degrees): ");
                 _sOrbitLAN = GUILayout.TextField(_sOrbitLAN, GUILayout.Width(50));
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label("Mean Anomaly: ");
+                GUILayout.Label("Mean Anomaly (radians): ");
                 _sOrbitMNA = GUILayout.TextField(_sOrbitMNA, GUILayout.Width(50));
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label("Argument of Periapsis: ");
+                GUILayout.Label("Argument of Periapsis (degrees): ");
                 _sOrbitArgPe = GUILayout.TextField(_sOrbitArgPe, GUILayout.Width(50));
                 GUILayout.EndHorizontal();
             }
@@ -142,17 +142,17 @@ namespace RP0
             GUILayout.EndHorizontal();
             if (_fromCurrentUT)
             {
-                GUILayout.Label("Accepts values with format \"1y 2d 3h 4m 5s\" or \"31719845\".");
+                GUILayout.Label("Valid formats: \"1y 2d 3h 4m 5s\" and \"31719845\".");
             }
             else
             {
-                GUILayout.Label("Accepts values with format \"1y 2d 3h 4m 5s\", \"1960-12-31 23:59:59\", or \"31719845\".");
+                GUILayout.Label("Valid formats: \"1y 2d 3h 4m 5s\", \"31719845\", and \"1960-12-31 23:59:59\".");
             }
             GUILayout.Space(4);
 
             if (ModUtils.IsTestFlightInstalled || ModUtils.IsTestLiteInstalled)
             {
-                simParams.DisableFailures = !GUILayout.Toggle(!simParams.DisableFailures, " Enable Part Failures with TestFlight or TestLite");
+                simParams.DisableFailures = !GUILayout.Toggle(!simParams.DisableFailures, " Enable Part Failures (TestFlight or TestLite)");
                 GUILayout.Space(4);
             }
 


### PR DESCRIPTION
Fix https://github.com/KSP-RO/RP-1/issues/2364.
Currently, only inputting Hours:minutes:seconds into the simulation window passes through [TryParseTimeString](https://github.com/KSP-RO/ROUtils/blob/master/Source/ROUtils/Utils/DTUtils.cs#L68) without any failures as expected, but this leads to some problem later down the line where the game starts timewarping rapidly (2364). This PR makes it so if the user is trying to specify a specific time, they must include the YYYY-MM-DD as well to avoid this error. (only putting in YYYY-MM-DD and not the HH:mm:ss is currently fine, as it just sets the time to midnight) All other formats should still work.

Also remind the user that they are allowed to specify seconds in that format, as it can be parsed perfectly fine.

RIP analemma