### PR TITLE
Do not require ECM for some apollo parts

### DIFF
--- a/Source/Tech Tree/Parts Browser/data/ROCapsules.json
+++ b/Source/Tech Tree/Parts Browser/data/ROCapsules.json
@@ -542,7 +542,7 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "",
+        "entry_cost_mods": "capsulesApollo",
         "identical_part_name": "",
         "module_tags": [
             "Reentry"
@@ -566,7 +566,7 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "",
+        "entry_cost_mods": "capsulesApollo",
         "identical_part_name": "Apollo Drogue Chutes",
         "module_tags": [
             "Reentry"
@@ -1073,7 +1073,7 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "",
+        "entry_cost_mods": "capsulesApollo",
         "identical_part_name": "Apollo Chutes",
         "module_tags": [
             "Reentry"
@@ -1097,7 +1097,7 @@
         "spacecraft": "",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "",
+        "entry_cost_mods": "capsulesApollo",
         "identical_part_name": "Apollo Chutes",
         "module_tags": [
             "Reentry"

--- a/Source/Tech Tree/Parts Browser/data/ROCapsules.json
+++ b/Source/Tech Tree/Parts Browser/data/ROCapsules.json
@@ -452,7 +452,7 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "capsulesApollo",
+        "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": []
     },
@@ -474,7 +474,7 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "dockingApollo, capsulesApollo",
+        "entry_cost_mods": "dockingApollo",
         "identical_part_name": "Apollo Probe",
         "module_tags": []
     },
@@ -497,7 +497,7 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "3000,dockingApollo, capsulesApollo",
+        "entry_cost_mods": "3000,dockingApollo",
         "identical_part_name": "Apollo Drogue",
         "module_tags": []
     },
@@ -542,7 +542,7 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "capsulesApollo",
+        "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
             "Reentry"
@@ -566,7 +566,7 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "capsulesApollo",
+        "entry_cost_mods": "",
         "identical_part_name": "Apollo Drogue Chutes",
         "module_tags": [
             "Reentry"
@@ -590,7 +590,7 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "capsulesApollo",
+        "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": []
     },
@@ -683,7 +683,7 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "dockingApollo, capsulesApollo",
+        "entry_cost_mods": "capsulesApollo",
         "identical_part_name": "Apollo Forward HS",
         "module_tags": [
             "Reentry"
@@ -732,7 +732,7 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "capsulesApollo",
+        "entry_cost_mods": "",
         "identical_part_name": "ApolloHGA",
         "module_tags": [
             "Instruments"
@@ -756,7 +756,7 @@
         "spacecraft": "",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "capsulesApollo",
+        "entry_cost_mods": "",
         "identical_part_name": "ApolloHGA",
         "module_tags": [
             "Instruments"
@@ -780,7 +780,7 @@
         "spacecraft": "",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "capsulesApolloBIII",
+        "entry_cost_mods": "",
         "identical_part_name": "ApolloHGABlockIII",
         "module_tags": [
             "Instruments"
@@ -804,7 +804,7 @@
         "spacecraft": "",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "35000, capsulesApolloBIII",
+        "entry_cost_mods": "35000",
         "identical_part_name": "",
         "module_tags": [
             "Instruments"
@@ -1073,7 +1073,7 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "capsulesApollo",
+        "entry_cost_mods": "",
         "identical_part_name": "Apollo Chutes",
         "module_tags": [
             "Reentry"
@@ -1097,7 +1097,7 @@
         "spacecraft": "",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "capsulesApollo",
+        "entry_cost_mods": "",
         "identical_part_name": "Apollo Chutes",
         "module_tags": [
             "Reentry"
@@ -1121,7 +1121,7 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "dockingApollo,capsulesApollo",
+        "entry_cost_mods": "dockingApollo",
         "identical_part_name": "Apollo Probe",
         "module_tags": []
     },


### PR DESCRIPTION
Fix https://github.com/KSP-RO/RP-1/issues/1926
ECM should only be required for parts that are directly linked to the development of another part (like heatshields linked to capsules)