### PR TITLE
Add KAC alarm for leader retirement and program deadline

### DIFF
--- a/Source/RP0/Leaders/StrategyRP0.cs
+++ b/Source/RP0/Leaders/StrategyRP0.cs
@@ -152,6 +152,10 @@ namespace RP0
                 CareerLog.Instance?.AddLeaderEvent(Config.Name, true, 0d);
                 KACWrapper.KAC.CreateAlarm(KACWrapper.KACAPI.AlarmTypeEnum.Crew, $"Retirement: {ConfigRP0.Title}", DateActivated + LongestDuration);
             }
+            else if (this is Programs.ProgramStrategy)
+            {
+                KACWrapper.KAC.CreateAlarm(KACWrapper.KACAPI.AlarmTypeEnum.Contract, $"Deadline: {ConfigRP0.Title}", Programs.deadlineUT);
+            }
         }
 
         /// <summary>

--- a/Source/RP0/Leaders/StrategyRP0.cs
+++ b/Source/RP0/Leaders/StrategyRP0.cs
@@ -130,7 +130,7 @@ namespace RP0
             isActive = true;
             Register();
             dateActivated = Planetarium.GetUniversalTime();
-            KACWrapper.KAC.CreateAlarm(KACWrapper.KACAPI.AlarmTypeEnum.Crew, $"Retirement: {ConfigRP0.Name}", DateActivated + LongestDuration);
+            KACWrapper.KAC.CreateAlarm(KACWrapper.KACAPI.AlarmTypeEnum.Crew, $"Retirement: {ConfigRP0.Title}", DateActivated + LongestDuration);
 
             // Update ActivatedStrategies to show that this strategy is currently active (and clobber
             // the UT it was last deactivated, if any).

--- a/Source/RP0/Leaders/StrategyRP0.cs
+++ b/Source/RP0/Leaders/StrategyRP0.cs
@@ -130,7 +130,6 @@ namespace RP0
             isActive = true;
             Register();
             dateActivated = Planetarium.GetUniversalTime();
-            KACWrapper.KAC.CreateAlarm(KACWrapper.KACAPI.AlarmTypeEnum.Crew, $"Retirement: {ConfigRP0.Title}", DateActivated + LongestDuration);
 
             // Update ActivatedStrategies to show that this strategy is currently active (and clobber
             // the UT it was last deactivated, if any).
@@ -151,6 +150,7 @@ namespace RP0
                 Programs.ProgramHandler.Instance.OnLeaderChange();
                 // FIXME add setup cost if we add setup costs to leaders
                 CareerLog.Instance?.AddLeaderEvent(Config.Name, true, 0d);
+                KACWrapper.KAC.CreateAlarm(KACWrapper.KACAPI.AlarmTypeEnum.Crew, $"Retirement: {ConfigRP0.Title}", DateActivated + LongestDuration);
             }
         }
 

--- a/Source/RP0/Leaders/StrategyRP0.cs
+++ b/Source/RP0/Leaders/StrategyRP0.cs
@@ -130,6 +130,7 @@ namespace RP0
             isActive = true;
             Register();
             dateActivated = Planetarium.GetUniversalTime();
+            KACWrapper.KAC.CreateAlarm(KACWrapper.KACAPI.AlarmTypeEnum.Crew, $"Retirement: {ConfigRP0.Name}", DateActivated + LongestDuration);
 
             // Update ActivatedStrategies to show that this strategy is currently active (and clobber
             // the UT it was last deactivated, if any).

--- a/Source/RP0/Leaders/StrategyRP0.cs
+++ b/Source/RP0/Leaders/StrategyRP0.cs
@@ -152,10 +152,6 @@ namespace RP0
                 CareerLog.Instance?.AddLeaderEvent(Config.Name, true, 0d);
                 KACWrapper.KAC.CreateAlarm(KACWrapper.KACAPI.AlarmTypeEnum.Crew, $"Retirement: {ConfigRP0.Title}", DateActivated + LongestDuration);
             }
-            else if (this is Programs.ProgramStrategy)
-            {
-                KACWrapper.KAC.CreateAlarm(KACWrapper.KACAPI.AlarmTypeEnum.Contract, $"Deadline: {ConfigRP0.Title}", Programs.deadlineUT);
-            }
         }
 
         /// <summary>

--- a/Source/RP0/Programs/Program.cs
+++ b/Source/RP0/Programs/Program.cs
@@ -282,6 +282,7 @@ namespace RP0.Programs
             p.ApplyProgramModifiers();
             p.totalFunding = p.TotalFunding;
             p.deadlineUT = p.acceptedUT + p.DurationYears * secsPerYear;
+            KACWrapper.KAC.CreateAlarm(KACWrapper.KACAPI.AlarmTypeEnum.Contract, $"Deadline: {title}", p.deadlineUT);
 
             Confidence.Instance.AddConfidence(-p.confidenceCosts[speed], TransactionReasonsRP0.ProgramActivation.Stock());
             CareerLog.Instance?.ProgramAccepted(p);

--- a/Source/RP0/Programs/Program.cs
+++ b/Source/RP0/Programs/Program.cs
@@ -282,7 +282,6 @@ namespace RP0.Programs
             p.ApplyProgramModifiers();
             p.totalFunding = p.TotalFunding;
             p.deadlineUT = p.acceptedUT + p.DurationYears * secsPerYear;
-            KACWrapper.KAC.CreateAlarm(KACWrapper.KACAPI.AlarmTypeEnum.Contract, $"Deadline: {title}", p.deadlineUT);
 
             Confidence.Instance.AddConfidence(-p.confidenceCosts[speed], TransactionReasonsRP0.ProgramActivation.Stock());
             CareerLog.Instance?.ProgramAccepted(p);


### PR DESCRIPTION
Fix https://github.com/KSP-RO/RP-1/issues/2073
I honestly have no idea if this is set up remotely correctly, as I pretty much just copy and pasted from [here](https://github.com/KSP-RO/RP-1/blob/0a7d57a8038295a2be002089f5aa4b27fe48e456/Source/RP0/UI/TrainingGUI.cs#L425). If this is set up, this should automatically create a KAC alarm that says "Retirement: [leader name]", with the time set to their retirement date. I did not do this for normal astronauts because their retirement dates can move. (leaders' retirement dates can't move, right?)