### PR TITLE
Add cost difference from previous vessel(s) while editing a vessel

### DIFF
--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -319,9 +319,23 @@ namespace RP0
             double fullVesselBP = SpaceCenterManagement.Instance.EditorVessel.buildPoints;
             double bpLeaderEffect = SpaceCenterManagement.Instance.EditorVessel.LeaderEffect;
             double effic = editedVessel.LC.Efficiency;
+            double usedShipsCost = 0d;
+            foreach (VesselProject v in SpaceCenterManagement.Instance.MergedVessels)
+            {
+                usedShipsCost += v.effectiveCost;
+            }
+            double costDifference = editedVessel.effectiveCost - usedShipsCost;
             KCTUtilities.GetShipEditProgress(editedVessel, out double newProgressBP, out double originalCompletionPercent, out double newCompletionPercent);
             GUILayout.Label($"Original: {Math.Max(0, originalCompletionPercent):P2}");
             GUILayout.Label($"Edited: {newCompletionPercent:P2}");
+            if (costDifference >= 0)
+            {
+                GUILayout.Label($"Cost Increase: +{costDifference:F0}");
+            }
+            else
+            {
+                GUILayout.Label($"Cost Decrease: -{costDifference:F0}");
+            }
             
             double rateWithCurEngis = KCTUtilities.GetBuildRate(editedVessel.LC, SpaceCenterManagement.Instance.EditorVessel.mass, SpaceCenterManagement.Instance.EditorVessel.buildPoints, SpaceCenterManagement.Instance.EditorVessel.humanRated, 0)
                 * effic * editedVessel.LC.StrategyRateMultiplier;


### PR DESCRIPTION
If this actually works, it will show how much more the new edited vessel will cost, compared to the previous unedited vessel(s).
Fixes https://github.com/KSP-RO/RP-1/issues/2072
(this is kinda dumb tbh)