### PR TITLE
Move CostExporter.csproj export path to \bin\Release\ to prevent unnecessary User folder being made

### DIFF
--- a/Source/CostExporter/CostExporter.csproj
+++ b/Source/CostExporter/CostExporter.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>C:\Users\nderaney\Documents\GitHub\RP-0\Source\Tech Tree\Parts Browser\</OutputPath>
+    <OutputPath>\bin\Release\</OutputPath>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   


### PR DESCRIPTION
While CostExporter does not need to be built usually, there is no need for its .csproj to lead to a custom Users folder (I think its NK's?) if someone builds it by accident.
Let me know if the output path should be set to something other than \bin\Release\, I just set it to that to get it out of the way. (and so KSP wouldn't try to load its dll if it was built by mistake)