### PR TITLE
Change ResearchPayload cost to prevent negative part costs.

### DIFF
--- a/GameData/RP-1/Contracts/RP0_Contract_Resources.cfg
+++ b/GameData/RP-1/Contracts/RP0_Contract_Resources.cfg
@@ -74,7 +74,7 @@ RESOURCE_DEFINITION
 {
   name = ResearchPayload
   density = 0.001
-  unitCost = 2.0
+  unitCost = 0.0
   flowMode = ALL_VESSEL
   transfer = PUMP
   isTweakable = true


### PR DESCRIPTION
Set ResearchPayload cost to 0 to prevent drained tanks having negative cost due to a KSP bug.
Currently, if you designate a tank as a ResearchPayload carrier but fully drain it of payload, its cost can become negative: https://discord.com/channels/319857228905447436/1295137142762242139/1338257875298156566