### PR TITLE
Limit duration of experimental Skopos contracts, and add warnings

### DIFF
--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_paris_moscow_tv.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_paris_moscow_tv.cfg
@@ -20,7 +20,7 @@ CONTRACT_TYPE {
 
   notes = France has a ground station with a cutting-edge antenna in Brittany, as part of its joint programme with the United States. However, Brittany is quite far West of the Soviet Union; you may need to adjust your designs accordingly.
 
-  completedMessage = Compatibility between French and Soviet satellite telecom systems has been confirmed.
+  completedMessage = Compatibility between French and Soviet satellite telecom systems has been confirmed. Maintain this connection for one year for further testing.
 
   // ************ REWARDS ************
   prestige = Trivial       // 1.0x
@@ -92,4 +92,9 @@ CONTRACT_TYPE {
   }
   
   %rewardFunds = 400
+}
+
+//Only run these for one year, in case player doesn't realize what they're getting into.
+@CONTRACT_TYPE[maintenance_intermittent_paris_moscow_tv]:AFTER[RP-1] {
+  %maxCompletions = 12
 }

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_paris_moscow_tv.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_paris_moscow_tv.cfg
@@ -82,9 +82,9 @@ CONTRACT_TYPE {
 }
 
 @CONTRACT_TYPE[maintenance_intermittent_paris_moscow_tv] {
-  %description = We would like to continue the experimental broadcasts between Moscow and Paris while an operational service is being set up.
+  %description = We would like to continue the experimental broadcasts between Moscow and Paris while an operational service is being set up. Month @index of 12.
   %synopsis = Support experimental transmissions between Moscow and Paris with an availability of 1% each month (approximately 7 h per month).
-  %completedMessage = We have completed another month of successful operation of the experimental Moscow–Paris connection.
+  %completedMessage = We have completed month @index of successful operation of the experimental Moscow–Paris connection.
   
   REQUIREMENT {
     type = ContractNotCompletedOnAcceptance
@@ -92,6 +92,23 @@ CONTRACT_TYPE {
   }
   
   %rewardFunds = 400
+  //Be nice and count for the player too.
+  DATA
+  {
+    type = int
+    index = $intermittent_paris_moscow_tv_Count + 0
+  }
+
+  BEHAVIOUR
+  {
+    name = IncrementTheCount
+    type = Expression
+    
+    CONTRACT_COMPLETED_SUCCESS
+    {
+      intermittent_paris_moscow_tv_Count = $intermittent_paris_moscow_tv_Count + 1
+    }
+  }
 }
 
 //Only run these for one year, in case player doesn't realize what they're getting into.

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_soviet_tv.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_soviet_tv.cfg
@@ -20,7 +20,7 @@ CONTRACT_TYPE {
 
   notes = Earth stations with large tracking antennas have been built in Moscow and Vladivostok.
 
-  completedMessage = The experiment has successfully demonstrated the viability of a space communications network for the Soviet Union, paving the way for an operational system.
+  completedMessage = The experiment has successfully demonstrated the viability of a space communications network for the Soviet Union, paving the way for an operational system. Maintain this connection for one year for further testing.
 
   // ************ REWARDS ************
   prestige = Trivial       // 1.0x
@@ -75,4 +75,9 @@ CONTRACT_TYPE {
   }
   
   %rewardFunds = 400
+}
+
+//Only run these for one year, in case player doesn't realize what they're getting into.
+@CONTRACT_TYPE[maintenance_intermittent_soviet_tv]:AFTER[RP-1] {
+  %maxCompletions = 12
 }

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_soviet_tv.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_soviet_tv.cfg
@@ -65,9 +65,9 @@ CONTRACT_TYPE {
 }
 
 @CONTRACT_TYPE[maintenance_intermittent_soviet_tv] {
-  %description = We would like to continue the experimental broadcasts between Moscow and Vladivostok while an operational service is being set up.
+  %description = We would like to continue the experimental broadcasts between Moscow and Vladivostok while an operational service is being set up. Month @index of 12.
   %synopsis = Support experimental transmissions between Moscow and Vladivostok with an availability of 1% each month (approximately 7 h per month).
-  %completedMessage = We have completed another month of successful operation of the experimental Moscow–Vladivostok connection.
+  %completedMessage = We have completed month @index of successful operation of the experimental Moscow–Vladivostok connection.
   
   REQUIREMENT {
     type = ContractNotCompletedOnAcceptance
@@ -75,6 +75,23 @@ CONTRACT_TYPE {
   }
   
   %rewardFunds = 400
+  //Be nice and count for the player too.
+  DATA
+  {
+    type = int
+    index = $intermittent_soviet_tv_Count + 0
+  }
+
+  BEHAVIOUR
+  {
+    name = IncrementTheCount
+    type = Expression
+    
+    CONTRACT_COMPLETED_SUCCESS
+    {
+      intermittent_soviet_tv_Count = $intermittent_soviet_tv_Count + 1
+    }
+  }
 }
 
 //Only run these for one year, in case player doesn't realize what they're getting into.

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_transatlantic_tv.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_transatlantic_tv.cfg
@@ -82,9 +82,9 @@ CONTRACT_TYPE {
 }
 
 @CONTRACT_TYPE[maintenance_intermittent_transatlantic_tv] {
-  %description = We would like to continue the experimental broadcasts across the Atlantic while an operational service is being set up.
+  %description = We would like to continue the experimental broadcasts across the Atlantic while an operational service is being set up. Month @index of 12.
   %synopsis = Provide transatlantic television with an availability of 1% each month (approximately 7 h per month).
-  %completedMessage = We have completed another month of successful operation of the experimental transatlantic television relay.
+  %completedMessage = We have completed month @index of successful operation of the experimental transatlantic television relay.
   
   REQUIREMENT {
     type = ContractNotCompletedOnAcceptance
@@ -92,6 +92,23 @@ CONTRACT_TYPE {
   }
   
   %rewardFunds = 400
+  //Be nice and count for the player too.
+  DATA
+  {
+    type = int
+    index = $intermittent_transatlantic_tv_Count + 0
+  }
+
+  BEHAVIOUR
+  {
+    name = IncrementTheCount
+    type = Expression
+    
+    CONTRACT_COMPLETED_SUCCESS
+    {
+      intermittent_transatlantic_tv_Count = $intermittent_transatlantic_tv_Count + 1
+    }
+  }
 }
 
 //Only run these for one year, in case player doesn't realize what they're getting into.

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_transatlantic_tv.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_transatlantic_tv.cfg
@@ -20,7 +20,7 @@ CONTRACT_TYPE {
 
   notes = Earth stations with cutting-edge antennas have been built at Andover (Maine, USA), Pleumeur-Bodou (Britanny, France), and Goonhilly Downs (Cornwall, UK). It should be possible to establish a transatlantic link with a very small satellite.\nThe experimental transatlantic transmissions are mutually exclusive; while you must provide support for both westward and eastward television broadcasts, your satellite does not need to have the capacity for those to happen at the same time.
 
-  completedMessage = The experiment has successfully demonstrated the viability of a transatlantic link via satellite, paving the way for a commercial operating system.
+  completedMessage = The experiment has successfully demonstrated the viability of a transatlantic link via satellite, paving the way for a commercial operating system. Maintain this connection for one year for further testing.
 
   // ************ REWARDS ************
 
@@ -92,4 +92,9 @@ CONTRACT_TYPE {
   }
   
   %rewardFunds = 400
+}
+
+//Only run these for one year, in case player doesn't realize what they're getting into.
+@CONTRACT_TYPE[maintenance_intermittent_transatlantic_tv]:AFTER[RP-1] {
+  %maxCompletions = 12
 }

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_transpacific_tv.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_transpacific_tv.cfg
@@ -19,7 +19,7 @@ CONTRACT_TYPE {
 
   notes = Earth stations with cutting-edge antennas have been built in Kashima (Ibaraki prefecture, Japan), and at Point Mugu (California, USA). It should be possible to establish a transpacific link with a very small satellite.
 
-  completedMessage = The experiment has successfully demonstrated the viability of a transpacific link via satellite, paving the way for a commercial operating system.
+  completedMessage = The experiment has successfully demonstrated the viability of a transpacific link via satellite, paving the way for a commercial operating system. Maintain this connection for one year for further testing.
 
   // ************ REWARDS ************
   prestige = Trivial       // 1.0x
@@ -75,4 +75,9 @@ CONTRACT_TYPE {
   }
   
   %rewardFunds = 400
+}
+
+//Only run these for one year, in case player doesn't realize what they're getting into.
+@CONTRACT_TYPE[maintenance_intermittent_transpacific_tv]:AFTER[RP-1] {
+  %maxCompletions = 12
 }

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_transpacific_tv.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_transpacific_tv.cfg
@@ -65,9 +65,9 @@ CONTRACT_TYPE {
 }
 
 @CONTRACT_TYPE[maintenance_intermittent_transpacific_tv] {
-  %description = We would like to continue the experimental broadcasts across the Pacific while an operational service is being set up.
+  %description = We would like to continue the experimental broadcasts across the Pacific while an operational service is being set up. Month @index of 12.
   %synopsis = Provide transpacific television with an availability of 1% each month (approximately 7 h per month).
-  %completedMessage = We have completed another month of successful operation of the experimental transpacific television relay.
+  %completedMessage = We have completed month @index of successful operation of the experimental transpacific television relay.
   
   REQUIREMENT {
     type = ContractNotCompletedOnAcceptance
@@ -75,6 +75,23 @@ CONTRACT_TYPE {
   }
   
   %rewardFunds = 400
+  //Be nice and count for the player too.
+  DATA
+  {
+    type = int
+    index = $intermittent_transpacific_tv_Count + 0
+  }
+
+  BEHAVIOUR
+  {
+    name = IncrementTheCount
+    type = Expression
+    
+    CONTRACT_COMPLETED_SUCCESS
+    {
+      intermittent_transpacific_tv_Count = $intermittent_transpacific_tv_Count + 1
+    }
+  }
 }
 
 //Only run these for one year, in case player doesn't realize what they're getting into.

--- a/GameData/RP-1/Contracts/Skopos_Contract_Configs.cfg
+++ b/GameData/RP-1/Contracts/Skopos_Contract_Configs.cfg
@@ -53,7 +53,7 @@
 }
 
 //Configuration for maintenance contracts
-+CONTRACT_TYPE:HAS[#agent[skopos_telecom_agent],#has_maintenance]:FOR[RP-1] {
++CONTRACT_TYPE:HAS[#agent[skopos_telecom_agent],#has_maintenance]:BEFORE[RP-1] {
 //rip out configuration of master contract, and set it up as a maintenance contract
 //name and title edited automatically, name, synopsis and message will be edited individually
   !REQUIREMENT,* {}

--- a/GameData/RP-1/Contracts/Skopos_Contract_Configs.cfg
+++ b/GameData/RP-1/Contracts/Skopos_Contract_Configs.cfg
@@ -1,7 +1,7 @@
 //just set some generic contract settings here in bulk to save time
 //Skopos contracts are telecom only at this point, so we can set them all up mostly the same
 //Use skopos telecom agent to detect a Skopos contract
-@CONTRACT_TYPE:HAS[#agent[skopos_telecom_agent]]:BEFORE[RP-1] {
+@CONTRACT_TYPE:HAS[#agent[skopos_telecom_agent]] {
 //No randomization in these, so no point in allowing them to be declined or regenerate
   cancellable = true
   declinable = false
@@ -53,7 +53,7 @@
 }
 
 //Configuration for maintenance contracts
-+CONTRACT_TYPE:HAS[#agent[skopos_telecom_agent],#has_maintenance]:BEFORE[RP-1] {
++CONTRACT_TYPE:HAS[#agent[skopos_telecom_agent],#has_maintenance] {
 //rip out configuration of master contract, and set it up as a maintenance contract
 //name and title edited automatically, name, synopsis and message will be edited individually
   !REQUIREMENT,* {}
@@ -91,7 +91,7 @@
 }
 
 //maintenance contracts repeat forever and always auto-accept (except for the level 0 contracts, which are overridden later)
-@CONTRACT_TYPE[maintenance_*]:FOR[RP-1] {
+@CONTRACT_TYPE[maintenance_*] {
   %maxCompletions = 0
   %autoAccept = true
 }

--- a/GameData/RP-1/Contracts/Skopos_Contract_Configs.cfg
+++ b/GameData/RP-1/Contracts/Skopos_Contract_Configs.cfg
@@ -53,7 +53,7 @@
 }
 
 //Configuration for maintenance contracts
-+CONTRACT_TYPE:HAS[#agent[skopos_telecom_agent],#has_maintenance] {
++CONTRACT_TYPE:HAS[#agent[skopos_telecom_agent],#has_maintenance]:FOR[RP-1] {
 //rip out configuration of master contract, and set it up as a maintenance contract
 //name and title edited automatically, name, synopsis and message will be edited individually
   !REQUIREMENT,* {}
@@ -90,8 +90,8 @@
   }
 }
 
-//maintenance contracts repeat forever and always auto-accept
-@CONTRACT_TYPE[maintenance_*] {
+//maintenance contracts repeat forever and always auto-accept (except for the level 0 contracts, which are overridden later)
+@CONTRACT_TYPE[maintenance_*]:FOR[RP-1] {
   %maxCompletions = 0
   %autoAccept = true
 }

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -402,7 +402,7 @@ RP0_PROGRAM
 {
 	name = SkoposCommercialApplications0
 	title = Early Commercial Applications
-	description = Although the earliest satellites were launched through government programs, commercial uses had been envisioned for a long time. Through this program, you will launch the earliest iterations of commercial-use satellites. With wildly varying needs, each satellite is dedicated to a specific requirement, typically with far more focused requirements than the earlier, broader scientific satellites. 
+	description = Although the earliest satellites were launched through government programs, commercial uses had been envisioned for a long time. Through this program, you will launch the earliest iterations of commercial-use satellites. With wildly varying needs, each satellite is dedicated to a specific requirement, typically with far more focused requirements than the earlier, broader scientific satellites. <br><color=red>Author's Note: These contracts will require a satellite relay to be maintained for ONE YEAR.</color>
 	requirementsPrettyText = Complete Early Satellites program
 	objectivesPrettyText = Launch the first commercial-use satellites and build a satellite communication network. 
 	nominalDurationYears = 4
@@ -618,7 +618,7 @@ RP0_PROGRAM
 {
 	name = SkoposCommercialApplications1
 	title = First Generation Commercial Applications
-	description = Geosynchronous, Geostationary, Molniya, and Tundra orbits have the potential to improve satellite coverage and simplify ground antenna tracking. This program tasks you with testing these orbits, launching satellites into them for commercial customers, and creating a satellite network for communication.
+	description = Geosynchronous, Geostationary, Molniya, and Tundra orbits have the potential to improve satellite coverage and simplify ground antenna tracking. This program tasks you with testing these orbits, launching satellites into them for commercial customers, and creating a satellite network for communication.<br><color=red>Author's Note: These contracts will require a satellite relay to be maintained FOREVER.</color>
 	requirementsPrettyText = Complete the Early Commercial Applications Program
 	objectivesPrettyText = Complete a First Generation Commercial Satellite Communications Network.
 	nominalDurationYears = 3.5
@@ -680,7 +680,7 @@ RP0_PROGRAM
 {
 	name = SkoposCommercialApplications2
 	title = Second Generation Commercial Applications
-	description = Geosynchronous, Geostationary, Molniya, and Tundra orbits have the potential to improve satellite coverage and simplify ground antenna tracking. This program tasks you with testing these orbits, launching satellites into them for commercial customers, and creating a satellite network for communication.
+	description = Geosynchronous, Geostationary, Molniya, and Tundra orbits have the potential to improve satellite coverage and simplify ground antenna tracking. This program tasks you with testing these orbits, launching satellites into them for commercial customers, and creating a satellite network for communication.<br><color=red>Author's Note: These contracts will require a satellite relay to be maintained FOREVER.</color>
 	requirementsPrettyText = Complete the First Generation Commercial Applications Program
 	objectivesPrettyText = Complete a Second Generation Commercial Satellite Communications Network.
 	nominalDurationYears = 3
@@ -741,7 +741,7 @@ RP0_PROGRAM
 {
 	name = SkoposCommercialApplications3
 	title = Third Generation Commercial Applications
-	description = Geosynchronous, Geostationary, Molniya, and Tundra orbits have the potential to improve satellite coverage and simplify ground antenna tracking. This program tasks you with testing these orbits, launching satellites into them for commercial customers, and creating a satellite network for communication.
+	description = Geosynchronous, Geostationary, Molniya, and Tundra orbits have the potential to improve satellite coverage and simplify ground antenna tracking. This program tasks you with testing these orbits, launching satellites into them for commercial customers, and creating a satellite network for communication.<br><color=red>Author's Note: These contracts will require a satellite relay to be maintained FOREVER.</color>
 	requirementsPrettyText = Complete the Second Generation Commercial Applications Program
 	objectivesPrettyText = Complete a Third Generation Commercial Satellite Communications Network.
 	nominalDurationYears = 5


### PR DESCRIPTION
Due to complaints, limit the duration of the Skopos contracts in the experimental program to 1 year. Also add warnings that Skopos contracts must be maintained forever once accepted.