### PR TITLE
Lower stringer mass to match empty Al Stringer tankage of the same year

### DIFF
--- a/GameData/RP-1/Tree/PFTechLevels.cfg
+++ b/GameData/RP-1/Tree/PFTechLevels.cfg
@@ -8,7 +8,7 @@ PARTUPGRADE
 	cost = 0
 	title = Aluminum Fairings and Stringers
 	manufacturer = Various
-	description = You can now use 1950s Aluminum stringer-stiffened fairings and stringers. The new minimum density is 0.155, compared with 0.180 at the previous tech level. NOTE: This is not a part you can use, it just symbolizes the new capabilities you can unlock. 
+	description = You can now use 1950s Aluminum stringer-stiffened fairings and stringers. The new minimum density is 0.135, compared with 0.180 for fairings and 0.300 for procedural structures at the previous tech level. NOTE: This is not a part you can use, it just symbolizes the new capabilities you can unlock. 
 }
 PARTUPGRADE
 {
@@ -19,7 +19,7 @@ PARTUPGRADE
 	cost = 0
 	title = Magnesium Fairings and Stringers
 	manufacturer = Various
-	description = You can now use 1960s Magnesium stringer-stiffened fairings and stringers. The new minimum density is 0.143, compared with 0.155 at the previous tech level. NOTE: This is not a part you can use, it just symbolizes the new capabilities you can unlock. 
+	description = You can now use 1960s Magnesium stringer-stiffened fairings and stringers. The new minimum density is 0.124, compared with 0.135 at the previous tech level. NOTE: This is not a part you can use, it just symbolizes the new capabilities you can unlock. 
 }
 PARTUPGRADE
 {
@@ -30,7 +30,7 @@ PARTUPGRADE
 	cost = 0
 	title = Fiberglass Fairings and Stringers
 	manufacturer = Various
-	description = You can now use late 1960s Fiberglass stringer-stiffened fairings and stringers. The new minimum density is 0.074, compared with 0.143 at the previous tech level. NOTE: This is not a part you can use, it just symbolizes the new capabilities you can unlock. 
+	description = You can now use late 1960s Fiberglass stringer-stiffened fairings and stringers. The new minimum density is 0.074, compared with 0.124 at the previous tech level. NOTE: This is not a part you can use, it just symbolizes the new capabilities you can unlock. 
 }
 PARTUPGRADE
 {
@@ -84,13 +84,13 @@ PARTUPGRADE
 			{
 				name__ = PFTech-Fairing-I
 				description__ = You can now use 1950s Aluminum stringer-stiffened fairings and stringers.
-				minDensity = 0.155
+				minDensity = 0.135
 			}
 			UPGRADE
 			{
 				name__ = PFTech-Fairing-II
 				description__ = You can now use 1960s Magnesium stringer-stiffened fairings and stringers.
-				minDensity = 0.143
+				minDensity = 0.124
 			}
 			UPGRADE
 			{


### PR DESCRIPTION
Currently, at 0.155 stringer mass procedural structures are overweight. This PR lowers the first upgrade to 0.135 to match empty Al Stringer parts, and the second upgrade to 0.124 to match the current relative reduction of that upgrade. It also clarifies that procedural structures begin at 0.300, and not 0.180.

Fixes #2512 