### PR TITLE
Remove max level requirements on tracking station for skopos contracts

### DIFF
--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/FirstComSat-SCA.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/FirstComSat-SCA.cfg
@@ -53,7 +53,6 @@ CONTRACT_TYPE
 			type = Facility
 			facility = TrackingStation
 			minLevel = 4
-			maxLevel = 11
 		}
 	}
 

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/FirstGEOSat-SCA.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/FirstGEOSat-SCA.cfg
@@ -78,7 +78,6 @@ CONTRACT_TYPE
 			type = Facility
 			facility = TrackingStation
 			minLevel = 4
-			maxLevel = 11
 		}
 	}
 

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/FirstGeosync-SCA.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/FirstGeosync-SCA.cfg
@@ -79,7 +79,6 @@ CONTRACT_TYPE
 			type = Facility
 			facility = TrackingStation
 			minLevel = 4
-			maxLevel = 11
 		}
 	}
 

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/FirstMolniyaSat-SCA.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/FirstMolniyaSat-SCA.cfg
@@ -81,7 +81,6 @@ CONTRACT_TYPE
 			type = Facility
 			facility = TrackingStation
 			minLevel = 4
-			maxLevel = 11
 		}
 	}
 

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/FirstTundraSat-SCA.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/FirstTundraSat-SCA.cfg
@@ -78,7 +78,6 @@ CONTRACT_TYPE
 			type = Facility
 			facility = TrackingStation
 			minLevel = 4
-			maxLevel = 11
 		}
 	}
 

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_paris_moscow_tv.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_paris_moscow_tv.cfg
@@ -39,7 +39,6 @@ CONTRACT_TYPE {
     type = Facility
     facility = TrackingStation
     minLevel = 4
-    maxLevel = 11
   }
 
   PARAMETER {

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_soviet_tv.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_soviet_tv.cfg
@@ -38,7 +38,6 @@ CONTRACT_TYPE {
 	type = Facility
 	facility = TrackingStation
 	minLevel = 4
-	maxLevel = 11
   }
 
   PARAMETER {

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_transatlantic_tv.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_transatlantic_tv.cfg
@@ -40,7 +40,6 @@ CONTRACT_TYPE {
 	type = Facility
 	facility = TrackingStation
 	minLevel = 4
-	maxLevel = 11
   }
 
   PARAMETER {

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_transpacific_tv.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 0/intermittent_transpacific_tv.cfg
@@ -38,7 +38,6 @@ CONTRACT_TYPE {
 	type = Facility
 	facility = TrackingStation
 	minLevel = 4
-	maxLevel = 11
   }
 
   PARAMETER {

--- a/GameData/RP-1/Contracts/Skopos Commercial Applications 3/l3_hermes_remote_tv.cfg
+++ b/GameData/RP-1/Contracts/Skopos Commercial Applications 3/l3_hermes_remote_tv.cfg
@@ -44,7 +44,6 @@ CONTRACT_TYPE {
 		type = Facility
 		facility = TrackingStation
 		minLevel = 7
-		maxLevel = 11
 	}
 
   PARAMETER {


### PR DESCRIPTION
Related: https://github.com/KSP-RO/RP-1/pull/2489

There already exists a spot in RP-1 where this is done with the Astronaut Complex for the First EVA contract, where minLevel is specified but maxLevel is not:
https://github.com/KSP-RO/RP-1/blob/3be415ae90102baaf8a797c43fd488af3829edc8/GameData/RP-1/Contracts/Earth%20Crewed%20Adv/FirstEVA.cfg#L61-L68

The contract configurator code also seems to be correctly set up to handle this situation:
https://github.com/KSP-RO/ContractConfigurator/blob/2d4ee9c189da88dc2edf08fd44b8ec6ac26fec1c/source/ContractConfigurator/Requirement/FacilityRequirement.cs#L63-L65
```requirementmet is true if (((no minlevel) or (level ge minlevel)) and ((no maxlevel) or (level le maxlevel)))```

This should be better for future proofing.