### PR TITLE
Add suppress notifications to Near Future mods

### DIFF
--- a/RP-1.netkan
+++ b/RP-1.netkan
@@ -92,9 +92,13 @@ suggests:
   - name: HullcamVDSContinued
   - name: InternalRCS
   - name: NearFutureConstruction
+    suppress_recommendations: true
   - name: NearFutureElectrical
+    suppress_recommendations: true
   - name: NearFutureExploration
+    suppress_recommendations: true
   - name: NearFutureSolar
+    suppress_recommendations: true
   - name: ShuttleOrbiterConstructionKit
   - name: BuranEnergia
   - name: RN-SovietSpacecraft


### PR DESCRIPTION
According to https://discord.com/channels/319857228905447436/620690446540341261/1345817564428767343, there is a strange issue where selecting community tree with RP-1 (non-express I think) [causes ckan to pick an older version of RP-1 without the community tech tree conflict](https://github.com/KSP-CKAN/CKAN/issues/4325). This PR removes recommendations from near future mods to prevent community tech tree from being suggested, although this is not a solution to the problem.