### PR TITLE
No MLI on battery tanks

### DIFF
--- a/GameData/RP-1/Tree/RFTechLevels.cfg
+++ b/GameData/RP-1/Tree/RFTechLevels.cfg
@@ -264,7 +264,7 @@ PARTUPGRADE
 
 @PART[*]:HAS[@MODULE[ModuleFuelTanks]]:AFTER[zzzRealFuels]
 {
-	@MODULE[ModuleFuelTanks]:HAS[~type[Tank-Balloon*]]
+	@MODULE[ModuleFuelTanks],*
 	{
 		%maxMLILayers = 0
 		@UPGRADES
@@ -308,6 +308,14 @@ PARTUPGRADE
 				description__ = Improved tank wrapping techniques allow 100 layers of MLI on balloon tanks.
 				maxMLILayers = 100
 			}
+		}
+	}
+	@MODULE[ModuleFuelTanks]:HAS[#type[Battery*]]
+	{
+		%maxMLILayers = 0
+		@UPGRADES
+		{
+			!UPGRADE:HAS[#name__[MLI*]] {}
 		}
 	}
 }


### PR DESCRIPTION
Prevent MLI from being used on avionics and other parts with battery-only tanks

resolves https://github.com/KSP-RO/RP-1/issues/2487