### PR TITLE
Revert "Move CostExporter.csproj export path to \bin\Release\ to prevent unnecessary User folder being made"

### DIFF
--- a/Source/CostExporter/CostExporter.csproj
+++ b/Source/CostExporter/CostExporter.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>\bin\Release\</OutputPath>
+    <OutputPath>C:\Users\nderaney\Documents\GitHub\RP-0\Source\Tech Tree\Parts Browser\</OutputPath>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   


### PR DESCRIPTION
Well this breaks the github actions and I do _not_ care enough to figure out why