### PR TITLE
Fix disconnect between avionics masses in procedural avionics window

### DIFF
--- a/GameData/RP-1/Tree/ProceduralAvionics.cfg
+++ b/GameData/RP-1/Tree/ProceduralAvionics.cfg
@@ -105,7 +105,7 @@ AVIONICSCONFIGS
 	AVIONICSCONFIG
 	{
 		name = Near-Earth
-		description = This part provides full control of the craft, instead of the limited control from Science core. The mass and volume of avionics necessary depend on tech level and the mass of the whole craft. It is functional only when close to Earth (up to 2x GEO distance). Uses: LV ascent guidance and upper stages that operate around the Earth.
+		description = This part provides full control of the craft, instead of the limited control from Science core. The mass and volume of avionics necessary depend on tech level and the mass of the whole craft. It is functional only when close to Earth (up to 2x GEO distance) due to a lack of shielding. Uses: LV ascent guidance and upper stages that operate around the Earth.
 
 		TECHLIMIT
 		{
@@ -447,7 +447,7 @@ AVIONICSCONFIGS
 	AVIONICSCONFIG
 	{
 		name = Deep-Space
-		description = This is the most advanced (and thus expensive) procedural avionics. Compared to to Near-Earth avionics, this works and offers control at any distance from Earth, and can be put on hibernation mode to save power. Uses: lunar and interplanetary probes, satellite buses when hibernation is desired.
+		description = This is the most advanced (and thus expensive) procedural avionics. Compared to to Near-Earth avionics, this works and offers control at any distance from Earth due to added TR (Thermal/Radiation) Shielding, and can be put on hibernation mode to save power. Uses: lunar and interplanetary probes, satellite buses when hibernation is desired.
 			
 		TECHLIMIT
 		{

--- a/GameData/RP-1/Tree/ProceduralAvionics.cfg
+++ b/GameData/RP-1/Tree/ProceduralAvionics.cfg
@@ -105,7 +105,7 @@ AVIONICSCONFIGS
 	AVIONICSCONFIG
 	{
 		name = Near-Earth
-		description = This part provides full control of the craft, instead of the limited control from Science core. The mass and volume of avionics necessary depend on tech level and the mass of the whole craft. It is functional only when close to Earth (up to 2x GEO distance) due to a lack of shielding. Uses: LV ascent guidance and upper stages that operate around the Earth.
+		description = This part provides full control of the craft, instead of the limited control from Science core. The mass and volume of avionics necessary depend on tech level and the mass of the whole craft. It is functional only when close to Earth (up to 2x GEO distance). Uses: LV ascent guidance and upper stages that operate around the Earth.
 
 		TECHLIMIT
 		{
@@ -447,7 +447,7 @@ AVIONICSCONFIGS
 	AVIONICSCONFIG
 	{
 		name = Deep-Space
-		description = This is the most advanced (and thus expensive) procedural avionics. Compared to to Near-Earth avionics, this works and offers control at any distance from Earth due to added TR (Thermal/Radiation) Shielding, and can be put on hibernation mode to save power. Uses: lunar and interplanetary probes, satellite buses when hibernation is desired.
+		description = This is the most advanced (and thus expensive) procedural avionics. Compared to to Near-Earth avionics, this works and offers control at any distance from Earth due to added complexity (Thermal/Radiation Shielding, Star Trackers, etc.), and can be put on hibernation mode to save power. Uses: lunar and interplanetary probes, satellite buses when hibernation is desired.
 			
 		TECHLIMIT
 		{

--- a/Source/RP0/Avionics/ModuleProceduralAvionics.cs
+++ b/Source/RP0/Avionics/ModuleProceduralAvionics.cs
@@ -130,7 +130,7 @@ namespace RP0.ProceduralAvionics
             return avionicsMass + GetShieldingMass(avionicsMass);
         }
 
-        private float GetShieldingMass(float avionicsMass) => Mathf.Pow(avionicsMass, 2f / 3) * CurrentProceduralAvionicsTechNode.shieldingMassFactor;
+        private float GetShieldingMass(float avionicsMass) => Mathf.Pow(avionicsMass, 2f / 3) * CurrentProceduralAvionicsTechNode.shieldingMassFactor; // use ^(2/3) to convert volume into surface
         private static float GetShieldingMass(ProceduralAvionicsTechNode techNode, float avionicsMass) => Mathf.Pow(avionicsMass, 2f / 3) * techNode.shieldingMassFactor;
 
         protected override float GetEnabledkW() => GetEnabledkW(CurrentProceduralAvionicsTechNode, GetInternalMassLimit());

--- a/Source/RP0/Avionics/ModuleProceduralAvionics.cs
+++ b/Source/RP0/Avionics/ModuleProceduralAvionics.cs
@@ -676,7 +676,7 @@ namespace RP0.ProceduralAvionics
             else if (controllableMass <= 0)
                 controllableMass = techNode.interplanetary ? 0.5f : 100f;
 
-            massKG = GetAvionicsMass(techNode, controllableMass) * 1000;
+            massKG = GetShieldedAvionicsMass(controllableMass) * 1000;
             cost = GetAvionicsCost(controllableMass, techNode);
             powerWatts = GetEnabledkW(techNode, controllableMass) * 1000;
             return controllableMass;

--- a/Source/RP0/Avionics/ModuleProceduralAvionics.cs
+++ b/Source/RP0/Avionics/ModuleProceduralAvionics.cs
@@ -591,11 +591,10 @@ namespace RP0.ProceduralAvionics
         public static string BuildPowerString(float enabledkW, float disabledkW)
         {
             var powerConsumptionBuilder = StringBuilderCache.Acquire();
-            powerConsumptionBuilder.Append("Online: ");
             powerConsumptionBuilder.Append(KERBALISM.Lib.HumanOrSIRate(enabledkW, KERBALISM.Lib.ECResID));
             if (disabledkW > 0)
             {
-                powerConsumptionBuilder.Append(" / Hibernated: ");
+                powerConsumptionBuilder.Append(" / ");
                 powerConsumptionBuilder.Append(KERBALISM.Lib.HumanOrSIRate(disabledkW, KERBALISM.Lib.ECResID));
             }
             return powerConsumptionBuilder.ToStringAndRelease();

--- a/Source/RP0/Avionics/ModuleProceduralAvionics.cs
+++ b/Source/RP0/Avionics/ModuleProceduralAvionics.cs
@@ -120,7 +120,6 @@ namespace RP0.ProceduralAvionics
         private float GetAvionicsMass() => GetAvionicsMass(GetInternalMassLimit());
         private float GetAvionicsMass(float controllableMass) => GetPolynomial(controllableMass, CurrentProceduralAvionicsTechNode.massExponent, CurrentProceduralAvionicsTechNode.massConstant, CurrentProceduralAvionicsTechNode.massFactor) / 1000f;
         private static float GetAvionicsMass(ProceduralAvionicsTechNode techNode, float controllableMass) => GetPolynomial(controllableMass, techNode.massExponent, techNode.massConstant, techNode.massFactor) / 1000f;
-        private static float GetShieldingMass(ProceduralAvionicsTechNode techNode, float avionicsMass) => Mathf.Pow(avionicsMass, 2f / 3) * techNode.shieldingMassFactor;
         private float GetAvionicsCost() => GetAvionicsCost(GetInternalMassLimit(), CurrentProceduralAvionicsTechNode);
         private static float GetAvionicsCost(float massLimit, ProceduralAvionicsTechNode techNode) => GetPolynomial(massLimit, techNode.costExponent, techNode.costConstant, techNode.costFactor);
         internal float GetAvionicsVolume() => GetAvionicsMass() / CurrentProceduralAvionicsTechNode.avionicsDensity;
@@ -132,6 +131,7 @@ namespace RP0.ProceduralAvionics
         }
 
         private float GetShieldingMass(float avionicsMass) => Mathf.Pow(avionicsMass, 2f / 3) * CurrentProceduralAvionicsTechNode.shieldingMassFactor;
+        private static float GetShieldingMass(ProceduralAvionicsTechNode techNode, float avionicsMass) => Mathf.Pow(avionicsMass, 2f / 3) * techNode.shieldingMassFactor;
 
         protected override float GetEnabledkW() => GetEnabledkW(CurrentProceduralAvionicsTechNode, GetInternalMassLimit());
         internal static float GetEnabledkW(ProceduralAvionicsTechNode techNode, float controllableMass) => GetPolynomial(controllableMass, techNode.powerExponent, techNode.powerConstant, techNode.powerFactor) / 1000f;

--- a/Source/RP0/Avionics/ModuleProceduralAvionics.cs
+++ b/Source/RP0/Avionics/ModuleProceduralAvionics.cs
@@ -120,6 +120,7 @@ namespace RP0.ProceduralAvionics
         private float GetAvionicsMass() => GetAvionicsMass(GetInternalMassLimit());
         private float GetAvionicsMass(float controllableMass) => GetPolynomial(controllableMass, CurrentProceduralAvionicsTechNode.massExponent, CurrentProceduralAvionicsTechNode.massConstant, CurrentProceduralAvionicsTechNode.massFactor) / 1000f;
         private static float GetAvionicsMass(ProceduralAvionicsTechNode techNode, float controllableMass) => GetPolynomial(controllableMass, techNode.massExponent, techNode.massConstant, techNode.massFactor) / 1000f;
+        private static float GetShieldingMass(ProceduralAvionicsTechNode techNode, float avionicsMass) => Mathf.Pow(avionicsMass, 2f / 3) * techNode.shieldingMassFactor;
         private float GetAvionicsCost() => GetAvionicsCost(GetInternalMassLimit(), CurrentProceduralAvionicsTechNode);
         private static float GetAvionicsCost(float massLimit, ProceduralAvionicsTechNode techNode) => GetPolynomial(massLimit, techNode.costExponent, techNode.costConstant, techNode.costFactor);
         internal float GetAvionicsVolume() => GetAvionicsMass() / CurrentProceduralAvionicsTechNode.avionicsDensity;
@@ -676,7 +677,8 @@ namespace RP0.ProceduralAvionics
             else if (controllableMass <= 0)
                 controllableMass = techNode.interplanetary ? 0.5f : 100f;
 
-            massKG = GetShieldedAvionicsMass(controllableMass) * 1000;
+            var avionicsMass = GetAvionicsMass(techNode, controllableMass);
+            massKG = (avionicsMass + GetShieldingMass(techNode, avionicsMass))*1000;
             cost = GetAvionicsCost(controllableMass, techNode);
             powerWatts = GetEnabledkW(techNode, controllableMass) * 1000;
             return controllableMass;

--- a/Source/RP0/Avionics/ModuleProceduralAvionics.cs
+++ b/Source/RP0/Avionics/ModuleProceduralAvionics.cs
@@ -119,7 +119,7 @@ namespace RP0.ProceduralAvionics
 
         private float GetAvionicsMass() => GetAvionicsMass(GetInternalMassLimit());
         private float GetAvionicsMass(float controllableMass) => GetPolynomial(controllableMass, CurrentProceduralAvionicsTechNode.massExponent, CurrentProceduralAvionicsTechNode.massConstant, CurrentProceduralAvionicsTechNode.massFactor) / 1000f;
-        private static float GetAvionicsMass(ProceduralAvionicsTechNode techNode, float controllableMass) => GetPolynomial(controllableMass, techNode.massExponent, techNode.massConstant, techNode.massFactor) / 1000f;
+        internal static float GetAvionicsMass(ProceduralAvionicsTechNode techNode, float controllableMass) => GetPolynomial(controllableMass, techNode.massExponent, techNode.massConstant, techNode.massFactor) / 1000f;
         private float GetAvionicsCost() => GetAvionicsCost(GetInternalMassLimit(), CurrentProceduralAvionicsTechNode);
         private static float GetAvionicsCost(float massLimit, ProceduralAvionicsTechNode techNode) => GetPolynomial(massLimit, techNode.costExponent, techNode.costConstant, techNode.costFactor);
         internal float GetAvionicsVolume() => GetAvionicsMass() / CurrentProceduralAvionicsTechNode.avionicsDensity;

--- a/Source/RP0/Avionics/ModuleProceduralAvionics.cs
+++ b/Source/RP0/Avionics/ModuleProceduralAvionics.cs
@@ -1,4 +1,4 @@
-﻿using RealFuels.Tanks;
+using RealFuels.Tanks;
 using System;
 using System.Collections.Generic;
 using UniLinq;
@@ -119,7 +119,7 @@ namespace RP0.ProceduralAvionics
 
         private float GetAvionicsMass() => GetAvionicsMass(GetInternalMassLimit());
         private float GetAvionicsMass(float controllableMass) => GetPolynomial(controllableMass, CurrentProceduralAvionicsTechNode.massExponent, CurrentProceduralAvionicsTechNode.massConstant, CurrentProceduralAvionicsTechNode.massFactor) / 1000f;
-        internal static float GetAvionicsMass(ProceduralAvionicsTechNode techNode, float controllableMass) => GetPolynomial(controllableMass, techNode.massExponent, techNode.massConstant, techNode.massFactor) / 1000f;
+        private static float GetAvionicsMass(ProceduralAvionicsTechNode techNode, float controllableMass) => GetPolynomial(controllableMass, techNode.massExponent, techNode.massConstant, techNode.massFactor) / 1000f;
         private float GetAvionicsCost() => GetAvionicsCost(GetInternalMassLimit(), CurrentProceduralAvionicsTechNode);
         private static float GetAvionicsCost(float massLimit, ProceduralAvionicsTechNode techNode) => GetPolynomial(massLimit, techNode.costExponent, techNode.costConstant, techNode.costFactor);
         internal float GetAvionicsVolume() => GetAvionicsMass() / CurrentProceduralAvionicsTechNode.avionicsDensity;
@@ -591,10 +591,11 @@ namespace RP0.ProceduralAvionics
         public static string BuildPowerString(float enabledkW, float disabledkW)
         {
             var powerConsumptionBuilder = StringBuilderCache.Acquire();
+            powerConsumptionBuilder.Append("Online: ");
             powerConsumptionBuilder.Append(KERBALISM.Lib.HumanOrSIRate(enabledkW, KERBALISM.Lib.ECResID));
             if (disabledkW > 0)
             {
-                powerConsumptionBuilder.Append(" / ");
+                powerConsumptionBuilder.Append(" / Hibernated: ");
                 powerConsumptionBuilder.Append(KERBALISM.Lib.HumanOrSIRate(disabledkW, KERBALISM.Lib.ECResID));
             }
             return powerConsumptionBuilder.ToStringAndRelease();
@@ -677,7 +678,7 @@ namespace RP0.ProceduralAvionics
             else if (controllableMass <= 0)
                 controllableMass = techNode.interplanetary ? 0.5f : 100f;
 
-            var avionicsMass = GetAvionicsMass(techNode, controllableMass);
+            float avionicsMass = GetAvionicsMass(techNode, controllableMass);
             massKG = (avionicsMass + GetShieldingMass(techNode, avionicsMass))*1000;
             cost = GetAvionicsCost(controllableMass, techNode);
             powerWatts = GetEnabledkW(techNode, controllableMass) * 1000;

--- a/Source/RP0/UI/ProceduralAvionicsWindow.cs
+++ b/Source/RP0/UI/ProceduralAvionicsWindow.cs
@@ -171,7 +171,7 @@ namespace RP0.ProceduralAvionics
                 float oldControlMass = _newControlMass;
                 if (float.TryParse(ControllableMass, out _newControlMass))
                 {
-                    float avionicsMass = _module.GetShieldedAvionicsMass(_newControlMass);
+                    float avionicsMass = _module.GetAvionicsMass(_newControlMass);
                     GUILayout.Label($" ({MathUtils.PrintMass(avionicsMass)})", HighLogic.Skin.label, GUILayout.Width(150));
                 }
 

--- a/Source/RP0/UI/ProceduralAvionicsWindow.cs
+++ b/Source/RP0/UI/ProceduralAvionicsWindow.cs
@@ -487,13 +487,18 @@ namespace RP0.ProceduralAvionics
             }
 
             float calcMass = ModuleProceduralAvionics.GetStatsForTechNode(techNode, _newControlMass, out float massKG, out _, out float powerWatts);
+            float shieldMass = massKG - (ModuleProceduralAvionics.GetAvionicsMass(techNode, _newControlMass)*1000);
             string indent = string.Empty;
             if (!techNode.IsScienceCore)
             {
                 sb.AppendLine($"At {calcMass:0.##}t controllable mass:");
                 indent = "  ";
             }
-            sb.AppendLine($"{indent}Mass: {massKG:0.#}kg");
+            sb.AppendLine($"{indent}Total Avionics Mass: {massKG:0.#}kg");
+            if (techNode.shieldingMassFactor > 0)
+            {
+                sb.AppendLine($"{indent}{indent}Shielding Mass: {shieldMass:0.#}kg");
+            }
             sb.AppendLine($"{indent}Power consumption: {powerWatts:0.#}W");
 
             sb.AppendLine($"Axial control: {BoolToYesNoString(techNode.allowAxial)}");

--- a/Source/RP0/UI/ProceduralAvionicsWindow.cs
+++ b/Source/RP0/UI/ProceduralAvionicsWindow.cs
@@ -487,17 +487,23 @@ namespace RP0.ProceduralAvionics
             }
 
             float calcMass = ModuleProceduralAvionics.GetStatsForTechNode(techNode, _newControlMass, out float massKG, out _, out float powerWatts);
-            float shieldMass = massKG - (ModuleProceduralAvionics.GetAvionicsMass(techNode, _newControlMass)*1000);
+            float nonShieldMass = ModuleProceduralAvionics.GetAvionicsMass(techNode, _newControlMass) * 1000;
+            float shieldMass = massKG - nonShieldMass;
             string indent = string.Empty;
             if (!techNode.IsScienceCore)
             {
                 sb.AppendLine($"At {calcMass:0.##}t controllable mass:");
                 indent = "  ";
             }
-            sb.AppendLine($"{indent}Total Avionics Mass: {massKG:0.#}kg");
             if (techNode.shieldingMassFactor > 0)
             {
-                sb.AppendLine($"{indent}{indent}Shielding Mass: {shieldMass:0.#}kg");
+                sb.AppendLine($"{indent}Total Avionics Mass: {massKG:0.#}kg");
+                sb.AppendLine($"{indent}{indent}Avionics Mass: {nonShieldMass:0.#}kg");
+                sb.AppendLine($"{indent}{indent}TR Shielding Mass: {shieldMass:0.#}kg"); // thermal/radiation shielding
+            }
+            else
+            {
+                sb.AppendLine($"{indent}Avionics Mass: {massKG:0.#}kg");
             }
             sb.AppendLine($"{indent}Power consumption: {powerWatts:0.#}W");
 

--- a/Source/RP0/UI/ProceduralAvionicsWindow.cs
+++ b/Source/RP0/UI/ProceduralAvionicsWindow.cs
@@ -497,13 +497,13 @@ namespace RP0.ProceduralAvionics
             }
             if (techNode.shieldingMassFactor > 0)
             {
-                sb.AppendLine($"{indent}Total Avionics Mass: {massKG:0.#}kg");
-                sb.AppendLine($"{indent}{indent}Avionics Mass: {nonShieldMass:0.#}kg");
-                sb.AppendLine($"{indent}{indent}TR Shielding Mass: {shieldMass:0.#}kg"); // thermal/radiation shielding
+                sb.AppendLine($"{indent}Total mass: {massKG:0.#}kg");
+                sb.AppendLine($"{indent}{indent}Avionics: {nonShieldMass:0.#}kg");
+                sb.AppendLine($"{indent}{indent}TR Shielding: {shieldMass:0.#}kg"); // thermal/radiation shielding
             }
             else
             {
-                sb.AppendLine($"{indent}Avionics Mass: {massKG:0.#}kg");
+                sb.AppendLine($"{indent}Avionics mass: {massKG:0.#}kg");
             }
             sb.AppendLine($"{indent}Power consumption: {powerWatts:0.#}W");
 

--- a/Source/RP0/UI/ProceduralAvionicsWindow.cs
+++ b/Source/RP0/UI/ProceduralAvionicsWindow.cs
@@ -171,7 +171,7 @@ namespace RP0.ProceduralAvionics
                 float oldControlMass = _newControlMass;
                 if (float.TryParse(ControllableMass, out _newControlMass))
                 {
-                    float avionicsMass = _module.GetAvionicsMass(_newControlMass);
+                    float avionicsMass = _module.GetShieldedAvionicsMass(_newControlMass);
                     GUILayout.Label($" ({MathUtils.PrintMass(avionicsMass)})", HighLogic.Skin.label, GUILayout.Width(150));
                 }
 

--- a/Source/RP0/UI/ProceduralAvionicsWindow.cs
+++ b/Source/RP0/UI/ProceduralAvionicsWindow.cs
@@ -487,24 +487,13 @@ namespace RP0.ProceduralAvionics
             }
 
             float calcMass = ModuleProceduralAvionics.GetStatsForTechNode(techNode, _newControlMass, out float massKG, out _, out float powerWatts);
-            float nonShieldMass = ModuleProceduralAvionics.GetAvionicsMass(techNode, _newControlMass) * 1000;
-            float shieldMass = massKG - nonShieldMass;
             string indent = string.Empty;
             if (!techNode.IsScienceCore)
             {
                 sb.AppendLine($"At {calcMass:0.##}t controllable mass:");
                 indent = "  ";
             }
-            if (techNode.shieldingMassFactor > 0)
-            {
-                sb.AppendLine($"{indent}Total mass: {massKG:0.#}kg");
-                sb.AppendLine($"{indent}{indent}Avionics: {nonShieldMass:0.#}kg");
-                sb.AppendLine($"{indent}{indent}TR Shielding: {shieldMass:0.#}kg"); // thermal/radiation shielding
-            }
-            else
-            {
-                sb.AppendLine($"{indent}Avionics mass: {massKG:0.#}kg");
-            }
+            sb.AppendLine($"{indent}Avionics mass: {massKG:0.#}kg");
             sb.AppendLine($"{indent}Power consumption: {powerWatts:0.#}W");
 
             sb.AppendLine($"Axial control: {BoolToYesNoString(techNode.allowAxial)}");


### PR DESCRIPTION
Reported by Krydax (https://discord.com/channels/319857228905447436/845457276641738782/1348458469983916082)
The top value was getting mass from GetShieldedAvionicsMass, while the bottom value was getting mass from GetAvionicsMass.

![image](https://github.com/user-attachments/assets/bd2870db-e9dc-4447-aae6-be5c9164e16d)

Actually, what even is 'shielding mass'? It seems to have been added all at once, with no real explanation for what it was, and then never used again. It might even be throwing off GetModuleMass and RefreshDisplays. Would it be safe to [remove all traces of this "shielding mass"](https://github.com/Clayell/RP-1/pull/2)?
Commits where it was added:
https://github.com/KSP-RO/RP-1/commit/a107763f0abe51d1ada9de388c690e3ed1919b2c
https://github.com/KSP-RO/RP-1/commit/08df9c823d79fba93b862f9e6f7ca57ea74bbcbb

Only present in these 3 files:
[ModuleProceduralAvionics.cs](https://github.com/KSP-RO/RP-1/blob/master/Source/RP0/Avionics/ModuleProceduralAvionics.cs)
[ProceduralAvionicsTechNode.cs](https://github.com/KSP-RO/RP-1/blob/36d2b3e566038d2bbd23844d7790b339a181cb0c/Source/RP0/Avionics/ProceduralAvionicsTechNode.cs#L27)
[ProceduralAvionics.cfg](https://github.com/KSP-RO/RP-1/blob/master/GameData/RP-1/Tree/ProceduralAvionics.cfg)