### PR TITLE
Fix double requirement of FO Heavy in polar sat contract

### DIFF
--- a/GameData/RP-1/Contracts/Early Satellites (Heavy)/FirstPolarSat-Heavy.cfg
+++ b/GameData/RP-1/Contracts/Early Satellites (Heavy)/FirstPolarSat-Heavy.cfg
@@ -89,25 +89,6 @@ CONTRACT_TYPE
 		invertRequirement = true
 	}
 
-	REQUIREMENT
-	{
-		name = Any
-		type = Any
-
-		REQUIREMENT
-		{
-			name = AcceptContractOrbit
-			type = AcceptContract
-			contractType = FirstSatellite-Heavy
-		}
-		REQUIREMENT
-		{
-			name = CompleteContract
-			type = CompleteContract
-			contractType = FirstSatellite-Heavy
-		}
-	}
-
 	PARAMETER
 	{
 		name = PolarSat


### PR DESCRIPTION
Reported by [Qazerowl](https://discord.com/channels/319857228905447436/620690446540341261/1350515505332486184)
https://github.com/KSP-RO/RP-1/pull/2428 required that users need to have completed the FO heavy contract before accepting this contract, however forgot to remove the requirement later in the contract where it required you to either accept or complete the FO heavy contract. This happens to not change the expected behavior at all, just makes it look weird visually.
![image](https://github.com/user-attachments/assets/b31d81a7-826d-49a4-b5ff-595169b2d590)
