### PR TITLE
Fix Yangel bonus, but for real

### DIFF
--- a/GameData/RP-1/Strategies/Leaders/LeadersEngineers.cfg
+++ b/GameData/RP-1/Strategies/Leaders/LeadersEngineers.cfg
@@ -152,7 +152,7 @@ STRATEGY
 		name = CurrencyModifier
 		effectTitle = Practiced Efficiency
 		currency = Funds
-		effectDescription = of vessel purchase and rollout
+		effectDescription = for vessel purchase and rollout
 		flipPositive = true
 		multiplier = 0.75
 		transactionReasons

--- a/GameData/RP-1/Strategies/Leaders/LeadersEngineers.cfg
+++ b/GameData/RP-1/Strategies/Leaders/LeadersEngineers.cfg
@@ -88,7 +88,7 @@ STRATEGY
 		name = CurrencyModifier
 		effectTitle = Created the R-7 LV
 		currency = Rate
-		effectDescription = of vessel integration, rollout and recovery
+		effectDescription = of vessel integration, rollout, and recovery
 		multiplier = 1.1
 		transactionReasons
 		{
@@ -167,7 +167,7 @@ STRATEGY
 		name = CurrencyModifier
 		effectTitle = Works for Us
 		currency = Rate
-		effectDescription = of vessel integration, rollout and recovery
+		effectDescription = of vessel integration, rollout, and recovery
 		multiplier = 1.05
 		transactionReasons
 		{

--- a/GameData/RP-1/Strategies/Leaders/LeadersEngineers.cfg
+++ b/GameData/RP-1/Strategies/Leaders/LeadersEngineers.cfg
@@ -152,14 +152,16 @@ STRATEGY
 		name = CurrencyModifier
 		effectTitle = Practiced Efficiency
 		currency = Funds
-		effectDescription = of vessel integration, rollout, and recovery
+		effectDescription = of vessel purchase and rollout
 		flipPositive = true
-		multiplier = 0.85
+		multiplier = 0.75
 		transactionReasons
 		{
-			item = PartOrUpgradeUnlock
+			item = Rollouts
+			item = VesselPurchase
 		}
 	}
+ 
 	EFFECT
 	{
 		name = CurrencyModifier

--- a/GameData/RP-1/Strategies/Leaders/LeadersEngineers.cfg
+++ b/GameData/RP-1/Strategies/Leaders/LeadersEngineers.cfg
@@ -88,7 +88,7 @@ STRATEGY
 		name = CurrencyModifier
 		effectTitle = Created the R-7 LV
 		currency = Rate
-		effectDescription = of vessel integration, rollout, and recovery
+		effectDescription = of vessel integration, rollout and recovery
 		multiplier = 1.1
 		transactionReasons
 		{
@@ -167,7 +167,7 @@ STRATEGY
 		name = CurrencyModifier
 		effectTitle = Works for Us
 		currency = Rate
-		effectDescription = of vessel integration, rollout, and recovery
+		effectDescription = of vessel integration, rollout and recovery
 		multiplier = 1.05
 		transactionReasons
 		{


### PR DESCRIPTION
Yangel was supposed to grant -15% from rollout, recovery and integration costs but:
Recovery cost are not an actual thing apparently, recovering costs 0 excluding the staff salary.
It's not clear to me what Integration costs are, i would imagine its the EffectiveCost of the rocket, since you pay for it over time, but no transactionReason affects it. (it would need to affect the engineer's salary only while they are working)
To fix the problem i opted for reducing the purchase cost instead, also maintaining the reduction to rollout cost.
The reasoning is that EC is often more than 2x the purchase cost so instead of 15% less EC it will reduce purchase cost and rollout by 25%.

I also removed a few reduntant commas from some leaders text.

Fixes #2540 
