### PR TITLE
Add heatshield requirement for early uncrewed orbital and sub-orbital reentry contracts

### DIFF
--- a/GameData/RP-1/Contracts/Earth Crewed/FirstOrbitRecovery.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed/FirstOrbitRecovery.cfg
@@ -96,6 +96,15 @@ CONTRACT_TYPE
 			title = Uncrewed
 			hideChildren = true
 		}
+    		PARAMETER
+		{
+			name = HasHeatshield
+			type = PartValidation
+			title = Include a heatsink or heatshield for reentry
+			part = ROH-AdjustableHS
+			part = ROC-MercuryHS			
+			hideChildren = true
+		}
 		PARAMETER
 		{
 			name = OrbitalVelocity

--- a/GameData/RP-1/Contracts/Earth Crewed/OrbitRecovery.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed/OrbitRecovery.cfg
@@ -115,6 +115,15 @@ CONTRACT_TYPE
 			title = Uncrewed
 			hideChildren = true
 		}
+  		PARAMETER
+		{
+			name = HasHeatshield
+			type = PartValidation
+			title = Include a heatsink or heatshield for reentry
+			part = ROH-AdjustableHS
+			part = ROC-MercuryHS			
+			hideChildren = true
+		}
 		PARAMETER
 		{
 			name = Orbit


### PR DESCRIPTION
No more cheesing the reentry using a large fairing with high stringer mass