### PR TITLE
Make CostExporter.csproj use $(ProjectDir) to prevent unnecessary User folder being made

### DIFF
--- a/Source/CostExporter/CostExporter.csproj
+++ b/Source/CostExporter/CostExporter.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>C:\Users\nderaney\Documents\GitHub\RP-0\Source\Tech Tree\Parts Browser\</OutputPath>
+    <OutputPath>\bin\Release\</OutputPath>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   

--- a/Source/CostExporter/CostExporter.csproj
+++ b/Source/CostExporter/CostExporter.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>\bin\Release\</OutputPath>
+    <OutputPath>$(ProjectDir)Source\Tech Tree\Parts Browser\</OutputPath>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   


### PR DESCRIPTION
Related: https://github.com/KSP-RO/RP-1/pull/2504
This should hopefully solve the build issues that were present in https://github.com/KSP-RO/RP-1/pull/2536, since it'll actually be sending it to the place that it expects. I mean, hopefully, assuming that github actions doesn't freak out again. If it does, then this is probably a lost cause 🤷.

Worked on my version of Visual Studio 2022:
![image](https://github.com/user-attachments/assets/f9aa23af-e918-44dc-af0d-2f4d5a96ecfb)
