### PR TITLE
Raise default height above atmosphere/ground in simulation to be 30000

### DIFF
--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -344,7 +344,7 @@ namespace RP0
 
         private static double GetDefaultAltitudeForBody(CelestialBody body)
         {
-            return body.atmosphere ? body.atmosphereDepth + 5000 : 20000;
+            return body.atmosphere ? body.atmosphereDepth + 30000 : 30000;
         }
     }
 }


### PR DESCRIPTION
Principia has some very strong perturbations, and not even the original 20,000 above atmosphere works. Doing +30000 (so, 170km) perturbs us down to 149.9km, so that should work. I've increased the default distance above the ground to +30000 based on the same principles, although TBH if you're using that feature on the moon Principia will wreck your craft decently quickly if you're below 200km anyway, so it's only a bandaid.

Simulating with +30km:
![image](https://github.com/user-attachments/assets/0552644e-0255-48b3-a306-da041137696d)
![image](https://github.com/user-attachments/assets/2e435ef2-2299-46d9-a67e-93628f15e294)
