### PR TITLE
Allow for commas in autohire GUI, allow for both errors to show up simultaneously

### DIFF
--- a/Source/RP0/UI/KCT/GUI_Personnel.cs
+++ b/Source/RP0/UI/KCT/GUI_Personnel.cs
@@ -436,7 +436,7 @@ namespace RP0
             bool b1 = int.TryParse(sNumStaff, out int numCrew);
             bool b2 = double.TryParse(sReserveFunds, out double reserveFunds);
 
-            string errorMessage = (!b1 ? "Failed to parse stadf count!\n" : "") + (!b2 ? "Failed to parse reserve funds!" : "");
+            string errorMessage = (!b1 ? "Failed to parse staff count!\n" : "") + (!b2 ? "Failed to parse reserve funds!" : "");
 
             if (!string.IsNullOrEmpty(errorMessage))
             {

--- a/Source/RP0/UI/KCT/GUI_Personnel.cs
+++ b/Source/RP0/UI/KCT/GUI_Personnel.cs
@@ -431,12 +431,17 @@ namespace RP0
 
         private static void TryAddAutoHire(string sNumStaff, string sReserveFunds, LaunchComplex lc)
         {
+            sNumStaff = sNumStaff.Replace(",", "");
+            sReserveFunds = sReserveFunds.Replace(",", "");
             bool b1 = int.TryParse(sNumStaff, out int numCrew);
             bool b2 = double.TryParse(sReserveFunds, out double reserveFunds);
-            if (!b1 || !b2)
+
+            string errorMessage = (!b1 ? "Failed to parse crew count!\n" : "") + (!b2 ? "Failed to parse reserve funds!" : "");
+
+            if (!string.IsNullOrEmpty(errorMessage))
             {
                 PopupDialog.SpawnPopupDialog(new MultiOptionDialog("warpToStaffConfirmFail",
-                    $"Failed to parse {(b1 ? "crew count" : "reserve funds")}!",
+                    errorMessage.Trim(),
                     "Error",
                     HighLogic.UISkin,
                     300,

--- a/Source/RP0/UI/KCT/GUI_Personnel.cs
+++ b/Source/RP0/UI/KCT/GUI_Personnel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine;
 using ROUtils;
 
@@ -436,7 +436,7 @@ namespace RP0
             bool b1 = int.TryParse(sNumStaff, out int numCrew);
             bool b2 = double.TryParse(sReserveFunds, out double reserveFunds);
 
-            string errorMessage = (!b1 ? "Failed to parse crew count!\n" : "") + (!b2 ? "Failed to parse reserve funds!" : "");
+            string errorMessage = (!b1 ? "Failed to parse stadf count!\n" : "") + (!b2 ? "Failed to parse reserve funds!" : "");
 
             if (!string.IsNullOrEmpty(errorMessage))
             {


### PR DESCRIPTION
Fix https://github.com/KSP-RO/RP-1/issues/2547.

Strips any commas from the strings before using them. (ReserveFunds doesn't even need to be stripped since it seems that double.TryParse can handle commas anyway, but there's no harm in doing it)
Additionally, previously only the "reserve funds" error was able to show up, even if the error was within parsing "crew count". This is because the "staff count" error would only show if the staff count had successfully parsed, which doesn't make any sense. I have changed this logic to allow for both error messages to show up at the same time if necessary.

![image](https://github.com/user-attachments/assets/8cf9d77a-a320-4ea3-bcea-276bdb598677)
![image](https://github.com/user-attachments/assets/a6837eb1-2bf5-4a10-85a4-3e806f42e199)
![image](https://github.com/user-attachments/assets/86bfe98a-63ed-41cd-95a3-27bd7c659a19)
