### PR TITLE
Make Skopos programs a bit less of an upgrade trap

### DIFF
--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -406,7 +406,7 @@ RP0_PROGRAM
 	requirementsPrettyText = Complete Early Satellites program
 	objectivesPrettyText = Launch the first commercial-use satellites and build a satellite communication network. 
 	nominalDurationYears = 4
-	baseFunding = 560000
+	baseFunding = 610000
 	fundingCurve = MildRampupCurve
 	repDeltaOnCompletePerYearEarly = 145
 	repPenaltyPerYearLate = 145
@@ -418,6 +418,12 @@ RP0_PROGRAM
 		{
 			complete_program = EarlySatellites
 			complete_program = EarlySatellites-Heavy
+		}
+		//Don't let the player start the program until they at least have a chance of getting the tracking station in time
+		FACILITY_LEVEL
+		{
+			facility = TrackingStation
+			level = 3
 		}
 	}
 	OBJECTIVES


### PR DESCRIPTION
Don't allow the experimental skopos program to be started until the tracking station is at least level 3, so you only need to buy 1 upgrade. Also increase the program payout by the cost of the tracking station upgrade.

This should prevent instances of players starting the skopos program immediately after first orbit and being forced to buy 2-3 tracking station upgrades to complete the program.