### PR TITLE
Allow later station parts to assign 2nd Gen Station Experiments

### DIFF
--- a/GameData/RP-1/Science/Experiments/CrewScience/StationExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/StationExperiments.cfg
@@ -13,6 +13,19 @@
 {
 	%capsuleTier = EarlyStation
 }
+@PART[*]:HAS[#TechRequired[modularSpaceStations],#CrewCapacity[>0]]:BEFORE[zzzKerbalism]
+{
+	%capsuleTier = EarlyStation
+}
+@PART[*]:HAS[#TechRequired[largeScaleOrbitalCon],#CrewCapacity[>0]]:BEFORE[zzzKerbalism]
+{
+	%capsuleTier = EarlyStation
+}
+@PART[*]:HAS[#TechRequired[improvedOrbitalConstruction],#CrewCapacity[>0]]:BEFORE[zzzKerbalism]
+{
+	%capsuleTier = EarlyStation
+}
+
 // ============================================================================
 // Long Duration Space Habitation 1
 // ============================================================================


### PR DESCRIPTION
Added 3 new placeholder capsuleTier definitions for Modular Space Stations, Large Scale Orbital Construction & Improved Orbital Construction. 
Assign the 'EarlyStation' tier to allow current 2nd generation experiments to be assigned