### PR TITLE
Small change on Programs.cfg for better readability

### DIFF
--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -19,30 +19,12 @@ RP0_PROGRAM
 			facility = AstronautComplex
 			level = 2
 		}
-		COMPLETE_CONTRACT
-		{
-			name = BreakSoundBarrier
-		}
-		COMPLETE_CONTRACT
-		{
-			name = XPlanesSupersonicMach2
-		}
-		COMPLETE_CONTRACT
-		{
-			name = XPlanesStratosphericResearch
-		}
-		COMPLETE_CONTRACT
-		{
-			name = XPlanesHighAltitude
-		}
-		COMPLETE_CONTRACT
-		{
-			name = XPlanesHypersonic
-		}
-		COMPLETE_CONTRACT
-		{
-			name = XPlanesKarman
-		}
+  		complete_contract = BreakSoundBarrier
+    		complete_contract = XPlanesSupersonicMach2
+	      	complete_contract = XPlanesStratosphericResearch
+	      	complete_contract = XPlanesHighAltitude
+	      	complete_contract = XPlanesHypersonic
+	      	complete_contract = XPlanesKarman
 	}
 	
 	OPTIONALS
@@ -112,25 +94,10 @@ RP0_PROGRAM
 
 	OBJECTIVES
 	{
-		COMPLETE_CONTRACT
-		{
-			name = KarmanLine
-		}
-		
-		COMPLETE_CONTRACT
-		{
-			name = SoundingRocketFilm
-		}
-		
-		COMPLETE_CONTRACT
-		{
-			name = SoundingRocketBio
-		}
-		
-		COMPLETE_CONTRACT
-		{
-			name = SoundingRocketAdvancedBio
-		}
+		complete_contract = KarmanLine
+		complete_contract = SoundingRocketFilm
+  		complete_contract = SoundingRocketBio
+    		complete_contract = SoundingRocketAdvancedBio
 	}
 	
 	OPTIONALS
@@ -1199,15 +1166,9 @@ RP0_PROGRAM
 			facility = AstronautComplex
 			level = 5
 		}
-		COMPLETE_CONTRACT
-		{
-			name = first_MoonFlybyCrewed
-		}
 		
-		COMPLETE_CONTRACT
-		{
-			name = FirstCrewedLunarOrbit
-		}
+  		complete_contract = first_MoonFlybyCrewed
+    		complete_contract = FirstCrewedLunarOrbit
 		
 		ANY
 		{


### PR DESCRIPTION
Just changing the `COMPLETE_CONTRACT` parameters for SIMPLER `complete_contract = _contract_name_` where the `COMPLETE_CONTRACT` parameter isn't actually needed just for readability. An example of where the `COMPLETE_CONTRACT` parameter is needed is when specifying a minCount of contracts needed (Example: RepeatMoonLandingCrew).