### PR TITLE
Increase R-103 cost

### DIFF
--- a/GameData/RP-1/Tree/TREE-Parts.cfg
+++ b/GameData/RP-1/Tree/TREE-Parts.cfg
@@ -11992,7 +11992,7 @@
 @PART[ROE-R103]:FOR[xxxRP0]
 {
     %TechRequired = unlockParts
-    %cost = 4
+    %cost = 12
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From ROEngines mod</color></b>

--- a/Source/Tech Tree/Parts Browser/data/ROEngines.json
+++ b/Source/Tech Tree/Parts Browser/data/ROEngines.json
@@ -4774,7 +4774,7 @@
         "title": "R-103 Booster",
         "description": "",
         "mod": "ROEngines",
-        "cost": 4,
+        "cost": 12,
         "entry_cost": 0,
         "category": "SOLID",
         "info": "",


### PR DESCRIPTION
Since it takes about 3 R-103s to match a Tiny Tim, make them cost a third of a Tiny Tim so they aren't really cheap any more.