### PR TITLE
Add methods related to alarms with and without KAC

### DIFF
--- a/Source/RP0/Harmony/Administration.cs
+++ b/Source/RP0/Harmony/Administration.cs
@@ -378,6 +378,11 @@ namespace RP0.Harmony
             if (!Administration.Instance.SelectedWrapper.strategy.Deactivate())
                 return;
 
+            if (Administration.Instance.SelectedWrapper.strategy is ProgramStrategy ps)
+            {
+                ps.ClearAlarms(ps.Title);
+            }
+
             Administration.Instance.UnselectStrategy();
             Administration.Instance.RedrawPanels();
         }

--- a/Source/RP0/Leaders/StrategyRP0.cs
+++ b/Source/RP0/Leaders/StrategyRP0.cs
@@ -1,10 +1,7 @@
 ﻿using KSP.Localization;
-using RP0.Programs;
 using Strategies;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEngine;
 
 namespace RP0
 {
@@ -148,7 +145,6 @@ namespace RP0
             if (useCurrency)
                 CurrencyUtils.ProcessCurrency(TransactionReasonsRP0.StrategySetup, ConfigRP0.SetupCosts, true);
 
-            UnityEngine.Debug.Log($"CLAYELADDEDLOGS ConfigRP0.Title: {ConfigRP0.Title}");
             if (this is Programs.ProgramStrategy ps)
             {
                 CreateAlarm($"Deadline: {ConfigRP0.Title}", $"{ConfigRP0.Title} must be completed at this time to avoid penalties.", ps.Program.deadlineUT);

--- a/Source/RP0/Leaders/StrategyRP0.cs
+++ b/Source/RP0/Leaders/StrategyRP0.cs
@@ -176,11 +176,11 @@ namespace RP0
             }
         }
 
-        internal void CreateAlarm(string title, string description, double UT)
-        {
+        internal void CreateAlarm(string title, string description, double UT, KACWrapper.KACAPI.AlarmTypeEnum alarmType = KACWrapper.KACAPI.AlarmTypeEnum.Crew)
+        { // dont set alarmType to contract, it seems to immediately delete itself?
             if (KACWrapper.KAC != null)
             {
-                string alarmID = KACWrapper.KAC.CreateAlarm(KACWrapper.KACAPI.AlarmTypeEnum.Crew, title, UT);
+                string alarmID = KACWrapper.KAC.CreateAlarm(alarmType, title, UT);
                 if (!string.IsNullOrEmpty(alarmID))
                 {
                     KACWrapper.KACAPI.KACAlarm alarm = KACWrapper.KAC.Alarms.First(z => z.ID == alarmID);

--- a/Source/RP0/Leaders/StrategyRP0.cs
+++ b/Source/RP0/Leaders/StrategyRP0.cs
@@ -1,5 +1,6 @@
 ﻿using Strategies;
 using KSP.Localization;
+using System.Linq;
 
 namespace RP0
 {
@@ -150,6 +151,16 @@ namespace RP0
                 Programs.ProgramHandler.Instance.OnLeaderChange();
                 // FIXME add setup cost if we add setup costs to leaders
                 CareerLog.Instance?.AddLeaderEvent(Config.Name, true, 0d);
+                if (RemovePenaltyDuration > 0)
+                {
+                    string alarmID = KACWrapper.KAC?.CreateAlarm(KACWrapper.KACAPI.AlarmTypeEnum.Crew, $"Free to Dismiss: {ConfigRP0.Title}", DateActivated + RemovePenaltyDuration);
+                    if (!string.IsNullOrEmpty(alarmID))
+                    {
+                        KACWrapper.KACAPI.KACAlarm alarm = KACWrapper.KAC.Alarms.First(z => z.ID == alarmID);
+
+                        alarm.Notes = $"{ConfigRP0.Title} can be removed without paying a penalty fee at this time.";
+                    }
+                }
                 if (LongestDuration > 0)
                 {
                     KACWrapper.KAC?.CreateAlarm(KACWrapper.KACAPI.AlarmTypeEnum.Crew, $"Retirement: {ConfigRP0.Title}", DateActivated + LongestDuration);


### PR DESCRIPTION
Fix https://github.com/KSP-RO/RP-1/issues/2517 (both parts)

CreateAlarm adds a way to make an alarm with a description that defaults to KAC if installed, but otherwise creates a stock alarm. I've made this trigger for:
- Program deadlines
- Leader retirement (although I don't think we use it anymore since https://github.com/KSP-RO/RP-1/pull/2569)
- Leader penalty fee expiration
- Leader reactivation cooldown
- Leader deactivation cooldown

ClearAlarms adds a way to remove all alarms (again accounting for KAC) with a certain string in the title. (to prevent duplicate alarms confusing people)
I've made this trigger when:
- Activating a leader
- Deactivating a leader
- Completing a program (no need to do it when activating the program, since the program can't have been activated before?)

Tested in-game to be working.

I'm not sure if "[program] must be completed at this time to avoid penalties." is the best choice of words, but I couldn't think of anything better.