### PR TITLE
Stop flickering of main KCT window when Build Plans Window is open

### DIFF
--- a/Source/RP0/UI/KCT/GUI_BuildPlans.cs
+++ b/Source/RP0/UI/KCT/GUI_BuildPlans.cs
@@ -69,8 +69,6 @@ namespace RP0
             }
             GUILayout.BeginHorizontal();
 
-            BuildListWindowPosition.height = EditorBuildListWindowPosition.height = 1;
-
             GUILayout.EndHorizontal();
             {
                 GUILayout.BeginHorizontal();


### PR DESCRIPTION
When the build plan window is open, the main window from KCT gets it's size set to 1 and back constantly whenever the mouse is button is being pressed.

I believe this line of code is the a remnant of some refactors done some years ago and it never got touched again. I did some local testing in the space center and in the VAB and didn't notice any loss of functionality, hence why i believe it's just left over code. More testing or some explanation would be appreciated though.