### PR TITLE
Station Science Module (Early) incorrect EC consumption in Kerbalism Planner

### DIFF
--- a/GameData/RP-1/Science/ScienceLabs.cfg
+++ b/GameData/RP-1/Science/ScienceLabs.cfg
@@ -1,3 +1,10 @@
+@PART[FASAGeminiMOLSci|L25mSci]:BEFORE[RP-0-Kerbalism]
+{
+	%MODULE[ModuleScienceConverter]
+	{
+	}
+}
+
 // add the Laboratory module and remove the stock module
 @PART[*]:HAS[@MODULE[ModuleScienceConverter],#CrewCapacity]:BEFORE[RP-0-Kerbalism]
 {
@@ -32,9 +39,3 @@
 	!MODULE[ModuleGenerator] {}
 }
 
-@PART[FASAGeminiMOLSci|L25mSci]:BEFORE[RP-0-Kerbalism]
-{
-	%MODULE[ModuleScienceConverter]
-	{
-	}
-}


### PR DESCRIPTION
Fixes issue with Kerbalism Planner reporting high EC consumption in Editor because of an unknown "lab" process.

https://discord.com/channels/418222516386004992/418222516386004994/1408348148023300109 

Adding `%MODULE[ModuleScienceConverter]` needs to happen before/above the patch that will look for all parts that have that module so it can replace it. Since it is currently at the bottom, it will add a blank module with no info and I Kerbalism is determining 5,000 Watts to be the max that a "lab" will consume.