### PR TITLE
Cheaper stringer tooling, more inheriting

### DIFF
--- a/GameData/RP-1/ToolingDefinitions.cfg
+++ b/GameData/RP-1/ToolingDefinitions.cfg
@@ -60,7 +60,7 @@ TOOLING_DEFINITION
 	title = Steel Fuselage
 	toolingName = Tool Tank
 	untooledMultiplier = 0.05
-	finalToolingCostMultiplier = 0.375
+	finalToolingCostMultiplier = 0.3
 	costMultiplierDL = 3
 	costReducers = Tank-Sep-Steel-HP:0.25
 }
@@ -70,7 +70,7 @@ TOOLING_DEFINITION
 	title = HP Steel Fuselage
 	toolingName = Tool Tank
 	untooledMultiplier = 0.05
-	finalToolingCostMultiplier = 0.375
+	finalToolingCostMultiplier = 0.3
 	costMultiplierDL = 3
 	costReducers = Tank-Sep-Steel:0.25
 }
@@ -80,7 +80,7 @@ TOOLING_DEFINITION
 	title = Al Fuselage
 	toolingName = Tool Tank
 	untooledMultiplier = 0.08
-	finalToolingCostMultiplier = 0.4
+	finalToolingCostMultiplier = 0.3
 	costMultiplierDL = 4
 	costReducers = Tank-Sep-Steel, Tank-Sep-Steel-HP, Tank-Sep-Al-HP:0.25
 }
@@ -90,7 +90,7 @@ TOOLING_DEFINITION
 	title = HP Al Fuselage
 	toolingName = Tool Tank
 	untooledMultiplier = 0.08
-	finalToolingCostMultiplier = 0.4
+	finalToolingCostMultiplier = 0.3
 	costMultiplierDL = 4
 	costReducers = Tank-Sep-Steel, Tank-Sep-Steel-HP, Tank-Sep-Al:0.25
 }
@@ -100,9 +100,9 @@ TOOLING_DEFINITION
 	title = Al Stringer Tank
 	toolingName = Tool Tank
 	untooledMultiplier = 0.08
-	finalToolingCostMultiplier = 0.5
+	finalToolingCostMultiplier = 0.35
 	costMultiplierDL = 5
-	costReducers = Tank-Sep-Al, Tank-Sep-Al-HP, Tank-Sep-Al2-HP:0.25
+	costReducers = Tank-Sep-Al, Tank-Sep-Al-HP, Tank-Sep-Al2-HP, Tank-Iso-Al, Tank-Iso-Al-HP:0.25
 }
 TOOLING_DEFINITION
 {
@@ -110,9 +110,9 @@ TOOLING_DEFINITION
 	title = HP Al Stringer Tank
 	toolingName = Tool Tank
 	untooledMultiplier = 0.08
-	finalToolingCostMultiplier = 0.5
+	finalToolingCostMultiplier = 0.35
 	costMultiplierDL = 5
-	costReducers = Tank-Sep-Al, Tank-Sep-Al-HP, Tank-Sep-Al2:0.25
+	costReducers = Tank-Sep-Al, Tank-Sep-Al-HP, Tank-Sep-Al2, Tank-Iso-Al, Tank-Iso-Al-HP:0.25
 }
 TOOLING_DEFINITION
 {
@@ -120,9 +120,9 @@ TOOLING_DEFINITION
 	title = Refined Al Stringer Tank
 	toolingName = Tool Tank
 	untooledMultiplier = 0.08
-	finalToolingCostMultiplier = 0.6
+	finalToolingCostMultiplier = 0.4
 	costMultiplierDL = 6
-	costReducers = Tank-Sep-Al2, Tank-Sep-Al2-HP, Tank-Sep-AlCu-HP:0.25
+	costReducers = Tank-Sep-Al2, Tank-Sep-Al2-HP, Tank-Sep-AlCu-HP, Tank-Iso-AlCu, Tank-Iso-AlCu-HP:0.25
 }
 TOOLING_DEFINITION
 {
@@ -130,9 +130,9 @@ TOOLING_DEFINITION
 	title = HP Refined Al Stringer Tank
 	toolingName = Tool Tank
 	untooledMultiplier = 0.08
-	finalToolingCostMultiplier = 0.6
+	finalToolingCostMultiplier = 0.4
 	costMultiplierDL = 6
-	costReducers = Tank-Sep-Al2, Tank-Sep-Al2-HP, Tank-Sep-AlCu:0.25
+	costReducers = Tank-Sep-Al2, Tank-Sep-Al2-HP, Tank-Sep-AlCu, Tank-Iso-AlCu, Tank-Iso-AlCu-HP:0.25
 }
 TOOLING_DEFINITION
 {
@@ -140,9 +140,9 @@ TOOLING_DEFINITION
 	title = Al-Li Stringer Tank
 	toolingName = Tool Tank
 	untooledMultiplier = 0.08
-	finalToolingCostMultiplier = 0.75
+	finalToolingCostMultiplier = 0.65	//Al-Li is a giant pain to work with
 	costMultiplierDL = 8
-	costReducers = Tank-Sep-AlCu, Tank-Sep-AlCu-HP, Tank-Sep-AlLi-HP:0.25
+	costReducers = Tank-Sep-AlCu, Tank-Sep-AlCu-HP, Tank-Sep-AlLi-HP, Tank-Iso-AlLi, Tank-Iso-AlLi-HP:0.25
 }
 TOOLING_DEFINITION
 {
@@ -150,9 +150,9 @@ TOOLING_DEFINITION
 	title = HP Al-Li Stringer Tank
 	toolingName = Tool Tank
 	untooledMultiplier = 0.08
-	finalToolingCostMultiplier = 0.75
+	finalToolingCostMultiplier = 0.65	//Al-Li is a giant pain to work with
 	costMultiplierDL = 8
-	costReducers = Tank-Sep-AlCu, Tank-Sep-AlCu-HP, Tank-Sep-AlLi:0.25
+	costReducers = Tank-Sep-AlCu, Tank-Sep-AlCu-HP, Tank-Sep-AlLi, Tank-Iso-AlLi, Tank-Iso-AlLi-HP:0.25
 }
 TOOLING_DEFINITION
 {
@@ -160,9 +160,9 @@ TOOLING_DEFINITION
 	title = Refined Al-Li Stringer Tank
 	toolingName = Tool Tank
 	untooledMultiplier = 0.1
-	finalToolingCostMultiplier = 0.6
+	finalToolingCostMultiplier = 0.45
 	costMultiplierDL = 6
-	costReducers = Tank-Sep-AlLi, Tank-Sep-AlLi-HP, Tank-Sep-Stir-HP:0.25
+	costReducers = Tank-Sep-AlLi, Tank-Sep-AlLi-HP, Tank-Sep-Stir-HP, Tank-Iso-AlLi, Tank-Iso-AlLi-HP:0.25
 }
 TOOLING_DEFINITION
 {
@@ -170,9 +170,9 @@ TOOLING_DEFINITION
 	title = HP Refined Al-Li Stringer Tank
 	toolingName = Tool Tank
 	untooledMultiplier = 0.1
-	finalToolingCostMultiplier = 0.6
+	finalToolingCostMultiplier = 0.45
 	costMultiplierDL = 6
-	costReducers = Tank-Sep-AlLi, Tank-Sep-AlLi-HP, Tank-Sep-Stir-HP:0.25
+	costReducers = Tank-Sep-AlLi, Tank-Sep-AlLi-HP, Tank-Sep-Stir-HP, Tank-Iso-AlLi, Tank-Iso-AlLi-HP:0.25
 }
 TOOLING_DEFINITION
 {
@@ -180,7 +180,7 @@ TOOLING_DEFINITION
 	title = Steel Stir-Welded Tank
 	toolingName = Tool Tank
 	untooledMultiplier = 0.05
-	finalToolingCostMultiplier = 0.49
+	finalToolingCostMultiplier = 0.35
 	costMultiplierDL = 6
 	costReducers = Tank-Sep-Stir, Tank-Sep-Stir-HP, Tank-Sep-Starship-HP:0.25
 }
@@ -190,7 +190,7 @@ TOOLING_DEFINITION
 	title = HP Steel Stir-Welded Tank
 	toolingName = Tool Tank
 	untooledMultiplier = 0.05
-	finalToolingCostMultiplier = 0.49
+	finalToolingCostMultiplier = 0.35
 	costMultiplierDL = 6
 	costReducers = Tank-Sep-Stir, Tank-Sep-Stir-HP, Tank-Sep-Starship-HP:0.25
 }


### PR DESCRIPTION
Considering conventional tanks are basically never worth it, significantly decrease their tooling costs. Also allow conventional tanks to inherit tooling discounts from isogrid tanks (since previous isogrid tanks could inherit from conventional tanks but not the other way around?)