### PR TITLE
Change time format information to a tooltip

### DIFF
--- a/Source/RP0/UI/KCT/GUI_Simulation.cs
+++ b/Source/RP0/UI/KCT/GUI_Simulation.cs
@@ -136,18 +136,10 @@ namespace RP0
 
             GUILayout.Space(4);
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Time: ");
+            GUILayout.Label(new GUIContent("Time: ", "Valid formats: \"1y 2d 3h 4m 5s\"" + (_fromCurrentUT ? " and \"31719845\"." : ", \"31719845\", and \"1960-12-31 23:59:59\".")));
             _UTString = GUILayout.TextField(_UTString, GUILayout.Width(110));
             _fromCurrentUT = GUILayout.Toggle(_fromCurrentUT, new GUIContent(" From Now", "If selected the game will warp forwards by the entered value. Otherwise the date and time will be set to the entered value."));
             GUILayout.EndHorizontal();
-            if (_fromCurrentUT)
-            {
-                GUILayout.Label("Valid formats: \"1y 2d 3h 4m 5s\" and \"31719845\".");
-            }
-            else
-            {
-                GUILayout.Label("Valid formats: \"1y 2d 3h 4m 5s\", \"31719845\", and \"1960-12-31 23:59:59\".");
-            }
             GUILayout.Space(4);
 
             if (ModUtils.IsTestFlightInstalled || ModUtils.IsTestLiteInstalled)


### PR DESCRIPTION
The label changed between stretching across one or two lines, so it would cause some extra whitespace at the bottom when the extra text went away until the window got reset.
<img width="348" height="432" alt="image" src="https://github.com/user-attachments/assets/732de9e9-5a08-41c6-88ad-2a063e7f45f9" />
<img width="365" height="427" alt="image" src="https://github.com/user-attachments/assets/76cc9922-d5d4-4c14-8b42-30a6f4831b6a" />
<img width="354" height="419" alt="image" src="https://github.com/user-attachments/assets/366bfee9-02c9-43e9-a7bb-b476f2e9fece" />

Changing it to a tooltip fixes this issue, and makes it a bit cleaner.
<img width="341" height="380" alt="image" src="https://github.com/user-attachments/assets/b356b723-c7f9-4172-8309-b7b26790b2e4" />
<img width="348" height="386" alt="image" src="https://github.com/user-attachments/assets/ee691c74-2e9e-4eb9-8c42-0f2d1c1f3325" />
