### PR TITLE
Actually configure 4-vernier LR91, remove old configs

### DIFF
--- a/GameData/RP-1/Tree/ECM-Parts.cfg
+++ b/GameData/RP-1/Tree/ECM-Parts.cfg
@@ -813,7 +813,7 @@
     ROE-LR89 = XLR43-NA-3
     ROE-LR89-2 = XLR43-NA-3
     ROE-LR91 = LR91-AJ-1
-    ROE-LR91-RN = LR91-AJ-1
+    ROE-LR91-4V = LR91-AJ-1
     ROE-LargeApolloLC = 1
     ROE-LargeApolloLC-FASA = 1
     ROE-LargeLC = 1

--- a/GameData/RP-1/Tree/TREE-Parts.cfg
+++ b/GameData/RP-1/Tree/TREE-Parts.cfg
@@ -11626,7 +11626,7 @@
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
-@PART[ROE-LR91-RN]:FOR[xxxRP0]
+@PART[ROE-LR91-4V]:FOR[xxxRP0]
 {
     %TechRequired = orbitalRocketry1959
     %cost = 370

--- a/GameData/RP-1/Tree/identicalParts.cfg
+++ b/GameData/RP-1/Tree/identicalParts.cfg
@@ -354,12 +354,11 @@
 @PART[RO-LR-89]:FOR[xxxRP0] { %identicalParts = RO-LR-89,ROE-LR89,ROE-LR89_2,bluedog_Atlas_LR89 }
 @PART[ROE-LR89]:FOR[xxxRP0] { %identicalParts = RO-LR-89,ROE-LR89,ROE-LR89_2,bluedog_Atlas_LR89 }
 @PART[ROE-LR89_2]:FOR[xxxRP0] { %identicalParts = RO-LR-89,ROE-LR89,ROE-LR89_2,bluedog_Atlas_LR89 }
-@PART[bluedog_LR91_mod1]:FOR[xxxRP0] { %identicalParts = ROE-LR91,ROE-LR91-RN,bluedog_LR91_mod1,bluedog_LR91_mod2,rn_lr91_11,rn_lr91_11_tp }
-@PART[bluedog_LR91_mod2]:FOR[xxxRP0] { %identicalParts = ROE-LR91,ROE-LR91-RN,bluedog_LR91_mod1,bluedog_LR91_mod2,rn_lr91_11,rn_lr91_11_tp }
-@PART[rn_lr91_11]:FOR[xxxRP0] { %identicalParts = ROE-LR91,ROE-LR91-RN,bluedog_LR91_mod1,bluedog_LR91_mod2,rn_lr91_11,rn_lr91_11_tp }
-@PART[rn_lr91_11_tp]:FOR[xxxRP0] { %identicalParts = ROE-LR91,ROE-LR91-RN,bluedog_LR91_mod1,bluedog_LR91_mod2,rn_lr91_11,rn_lr91_11_tp }
-@PART[ROE-LR91]:FOR[xxxRP0] { %identicalParts = ROE-LR91,ROE-LR91-RN,bluedog_LR91_mod1,bluedog_LR91_mod2,rn_lr91_11,rn_lr91_11_tp }
-@PART[ROE-LR91-RN]:FOR[xxxRP0] { %identicalParts = ROE-LR91,ROE-LR91-RN,bluedog_LR91_mod1,bluedog_LR91_mod2,rn_lr91_11,rn_lr91_11_tp }
+@PART[bluedog_LR91_mod1]:FOR[xxxRP0] { %identicalParts = ROE-LR91,bluedog_LR91_mod1,bluedog_LR91_mod2,rn_lr91_11,rn_lr91_11_tp }
+@PART[bluedog_LR91_mod2]:FOR[xxxRP0] { %identicalParts = ROE-LR91,bluedog_LR91_mod1,bluedog_LR91_mod2,rn_lr91_11,rn_lr91_11_tp }
+@PART[rn_lr91_11]:FOR[xxxRP0] { %identicalParts = ROE-LR91,bluedog_LR91_mod1,bluedog_LR91_mod2,rn_lr91_11,rn_lr91_11_tp }
+@PART[rn_lr91_11_tp]:FOR[xxxRP0] { %identicalParts = ROE-LR91,bluedog_LR91_mod1,bluedog_LR91_mod2,rn_lr91_11,rn_lr91_11_tp }
+@PART[ROE-LR91]:FOR[xxxRP0] { %identicalParts = ROE-LR91,bluedog_LR91_mod1,bluedog_LR91_mod2,rn_lr91_11,rn_lr91_11_tp }
 @PART[RO_DIRECT_STS_LWT]:FOR[xxxRP0] { %identicalParts = RO_DIRECT_STS_LWT,RO_SSS_STS_LWT }
 @PART[RO_SSS_STS_LWT]:FOR[xxxRP0] { %identicalParts = RO_DIRECT_STS_LWT,RO_SSS_STS_LWT }
 @PART[RO_bluedog_M1]:FOR[xxxRP0] { %identicalParts = ROE-M1,RO_bluedog_M1 }

--- a/Source/Tech Tree/Parts Browser/data/ROEngines.json
+++ b/Source/Tech Tree/Parts Browser/data/ROEngines.json
@@ -3809,26 +3809,24 @@
         ]
     },
     {
-        "name": "ROE-LR91-RN",
-        "title": "LR91 Series",
+        "name": "ROE-LR91-4V",
+        "title": "LR91 Series (4-vernier)",
         "description": "",
         "mod": "ROEngines",
-        "cost": 370,
-        "entry_cost": 0,
+        "cost": "370",
+        "entry_cost": "0",
         "category": "ORBITAL",
         "info": "",
         "year": "1959",
         "technology": "orbitalRocketry1959",
-        "era": "",
         "ro": true,
-        "rp0": true,
         "orphan": false,
         "rp0_conf": true,
-        "spacecraft": "Titan",
+        "spacecraft": "",
         "engine_config": "LR91",
         "upgrade": false,
         "entry_cost_mods": "LR91-AJ-1",
-        "identical_part_name": "LR91",
+        "identical_part_name": "",
         "module_tags": [
             "EngineLiquidTurbo"
         ]


### PR DESCRIPTION
Actually configure the 4-vernier LR91 so you can use it in RP-1, remove some very old configs for old deprecated LR91 parts.