### PR TITLE
Mission Modules as 'free flyers' for very limited station science

### DIFF
--- a/GameData/RP-1/Science/Configure.cfg
+++ b/GameData/RP-1/Science/Configure.cfg
@@ -1167,6 +1167,15 @@
 	}
 }
 
+//Prototype station science - limited Mission Module support
+@PART[ROC-D2MissionModule2|rn_tks]:AFTER[zzzKerbalism]
+{
+	@MODULE[Configure]:HAS[#title[Crew?Science]]
+	{
+		@slots = 1
+	}
+}
+
 //Early Space Stations
 @PART[*]:HAS[#capsuleTier[EarlyStation]]:AFTER[zzzKerbalism]
 {
@@ -1381,6 +1390,15 @@
 			  id_value = RP0LunarOrbitHabit
 			}
 		}
+	}
+}
+
+//Early station science - limited Mission Module support
+@PART[ROC-ApolloMissionModule|ROC-ApolloMissionModule4|ROC-BigGeminiSM]:AFTER[zzzKerbalism]
+{
+	@MODULE[Configure]:HAS[#title[Crew?Science]]
+	{
+		@slots = 1
 	}
 }
 

--- a/GameData/RP-1/Science/Experiments/CrewScience/StationExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/StationExperiments.cfg
@@ -17,7 +17,7 @@
 {
 	%capsuleTier = EarlyStation
 }
-@PART[ROC-ApolloMissionModule|ROC-ApolloMissionModule4|ROC-BigGeminiSM]:BEFORE[zzzKerbalism]
+@PART[ROC-ApolloMissionModule|ROC-ApolloMissionModule4|rn_tks|ROC-BigGeminiSM]:BEFORE[zzzKerbalism]
 {
 	%capsuleTier = EarlyStation
 }

--- a/GameData/RP-1/Science/Experiments/CrewScience/StationExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/StationExperiments.cfg
@@ -9,7 +9,15 @@
 {
 	%capsuleTier = StationPrototypeAndDevelopment
 }
+@PART[ROC-D2MissionModule2|rn_tks]:BEFORE[zzzKerbalism]
+{
+	%capsuleTier = StationPrototypeAndDevelopment
+}
 @PART[*]:HAS[#TechRequired[earlySpaceStations],#CrewCapacity[>0]]:BEFORE[zzzKerbalism]
+{
+	%capsuleTier = EarlyStation
+}
+@PART[ROC-ApolloMissionModule|ROC-ApolloMissionModule4|ROC-BigGeminiSM]:BEFORE[zzzKerbalism]
 {
 	%capsuleTier = EarlyStation
 }

--- a/GameData/RP-1/Science/ScienceLabs.cfg
+++ b/GameData/RP-1/Science/ScienceLabs.cfg
@@ -21,17 +21,6 @@
 	}
 }
 
-@PART[ROC-ApolloMissionModule4]:NEEDS[ROCapsules]:AFTER[ROCapsules]
-{
-	MODULE
-	{
-		name = Laboratory
-		ec_rate = 0.07
-		analysis_rate = 0.0000025
-		researcher = Scientist
-	}
-}
-
 // part specific patches
 @PART[Large_Crewed_Lab|L25mSci]:AFTER[RP-0-Kerbalism]
 {


### PR DESCRIPTION
This change was discussed at length on Discord yesterday, with some interest and consensus, so here's my first pass at it:

- **Adds** a single Prototype Station science experiment slot to Apollo D-2 Block II Mission Module and TKS Service Module (Mature Capsules; same era as Station Prototypes) 
- **Adds** a single Early Station science experiment slot to Apollo Block IV Mission Module and the service modules for TKS and Big Gemini (Improved Capsules; same era as Early Stations)
- **Removes** the Lab capability from Apollo Block IV Mission Module, although as it's located in Advanced Capsules perhaps there is an argument for it

There is interest (on the discord) in the creation of future station programs that would be more permissive in *how* they are accomplished. A great deal of research starting at least in the 60s went into so-called "free flyers", small modules that could be operated for shorter periods of scientific study than a full size space station. Their size would be both an advantage, allowing the use of smaller and cheaper launchers, and a disadvantage, limiting their capabilities significantly. The speculative Apollo Mission Modules we have in RP-1 now, based on the ETS alt history, are directly derived from Apollo Applications Program proposals that preceded the cut-back Skylab program.