### PR TITLE
Reduce Outer Planet Flyby slot count, add optional Titan Flyby

### DIFF
--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -1361,13 +1361,12 @@ RP0_PROGRAM
 	{
 		ATLEAST
 		{
-			count = 5
+			count = 4
 			complete_contract = flybyJupiter
 			complete_contract = flybySaturn
 			complete_contract = flybyUranus
 			complete_contract = flybyNeptune
 			complete_contract = flybyPluto
-			complete_contract = flybyTitan
 		}
 	}
 	
@@ -1380,6 +1379,7 @@ RP0_PROGRAM
 	OPTIONALS
 	{
 		flybyCharon = true
+		flybyTitan = true
 	}
 }
 

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -1368,7 +1368,6 @@ RP0_PROGRAM
 			complete_contract = flybyNeptune
 			complete_contract = flybyPluto
 			complete_contract = flybyTitan
-
 		}
 	}
 	

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -1350,7 +1350,7 @@ RP0_PROGRAM
 	repDeltaOnCompletePerYearEarly = 285
 	repPenaltyPerYearLate = 285
 	repToConfidence = 4
-	slots = 3
+	slots = 2
 
 	REQUIREMENTS
 	{

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -1361,12 +1361,14 @@ RP0_PROGRAM
 	{
 		ATLEAST
 		{
-			count = 4
+			count = 5
 			complete_contract = flybyJupiter
 			complete_contract = flybySaturn
 			complete_contract = flybyUranus
 			complete_contract = flybyNeptune
 			complete_contract = flybyPluto
+			complete_contract = flybyTitan
+
 		}
 	}
 	


### PR DESCRIPTION
Currently, completion of Outer Planet Flyby requires flyby of at least 4/5 of Jupiter, Saturn, Uranus, Neptune, Pluto, with Charon as an optional. This makes little sense to me, as I have not heard of a combination of trajectories which would flyby only 3 of the gas giants plus Pluto as opposed to just the 4 gas giants as Voyager 2 did. IRL Voyager 1 sacrificed the Pluto flyby opportunity to study Titan instead, and the periapsis (6490km) was well within the 20Mm limit required by the Titan Flyby contract in RP-1.

This PR adds Titan to the list of required completions and require 5 out of 6, which means the player would probably do the 4 gas giants and then flyby either Titan or Pluto. I still think it is weird and I would ideally like to make the gas giants all compulsory and just have an ANY block for either Pluto or Titan, with Charon remaining as optional, but I assume there is a reason it is written like this. Or we could make both Pluto and Titan optional and just require the 4 gas giants for program completion.

This has a slight impact on Saturn Observation since Titan Flyby is required there, but I assume most players will do Titan atmo probe instead of Saturn so the player would probably go to Titan again anyway? I don't think it's a major balance issue.