### PR TITLE
Allow two additional Admin building levels to be built

### DIFF
--- a/GameData/RP-1/CustomBarnKit.cfg
+++ b/GameData/RP-1/CustomBarnKit.cfg
@@ -48,11 +48,11 @@
 	}
 	@ADMINISTRATION
 	{
-		@levels = 9
-		@upgradesVisual = 1, 1, 2, 2, 2, 3, 3, 3, 3
-		@upgrades = 25000, 40000, 140000, 250000, 400000, 500000, 500000, 500000, 500000
-		@activeStrategyLimit = 5, 6, 7, 8, 9, 10, 11, 12, 13
-		@strategyCommitRange = 0, 0, 0, 0, 0, 0, 0, 0, 0
+		@levels = 11
+		@upgradesVisual = 1, 1, 2, 2, 2, 3, 3, 3, 3, 3, 3
+		@upgrades = 25000, 40000, 140000, 250000, 400000, 500000, 500000, 500000, 500000, 500000, 600000
+		@activeStrategyLimit = 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+		@strategyCommitRange = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 	}
 
 	// Cosmetic only - level set by code to match other buildings


### PR DESCRIPTION
This allows two additional Administration building levels to be built, allowing up to 15 program slots at max level. With all the new proposed programs, and so many of them being deep space programs, having 15 program slots allows for a lot more flexibility in the very late game regarding deep space programs, so you can pick up something else to do while waiting on the extremely long transfers to some of the outer planets. 15 just also plays much nicer with the program slot levels that we have, because most of the deep space programs are 3 slots, and bigger lategame ones like ELH and crewed mars are 4 and 6 respectively. This means that you could neatly have 3 deep space programs that you're waiting on in the background while completing Marsboots (15 slots), or 2 while doing Early Space Stations and ELH (14 slots). 

Plus, this gives something else to build besides the tracking station in the late game. Post Moonboots, there's not a whole lot to build short of making a giga LC for Marsboots, so the absence of another lategame funds sink is definitely noticeable, especially around the time of Marsboots.

I'm very open to feedback regarding the upgrade costs of these as well.