### PR TITLE
Standardise spaceplane ECM

### DIFF
--- a/GameData/RP-1/Tree/EntryCostModifiers.cfg
+++ b/GameData/RP-1/Tree/EntryCostModifiers.cfg
@@ -549,10 +549,10 @@ ENTRYCOSTMODS
 
 	// Spaceplanes
 		hypersonicCockpit = 25000
-		protoSpaceCockpit = 120000, hypersonicCockpit, capsulesAirlock
+		protoSpaceCockpit = 420000, hypersonicCockpit, capsulesAirlock
 		spaceCockpit = 500000, protoSpaceCockpit
-		X20 = 350000, protoSpaceCockpit	//545000 total
-		STS = 3100000, spaceCockpit
+		X20 = 50000, protoSpaceCockpit	//545000 total
+		STS = 2800000, spaceCockpit
 
 //**********************************************************************************
 //  COMMUNICATIONS


### PR DESCRIPTION
Currently, the X-20 costs far more to unlock than an equivalent generic spaceplane. This PR shifts a larger part of the X-20 unlock cost to the base modifier (protoSpaceCockpit), while maintaining the same over-all cost, as discussed in [2753](https://github.com/KSP-RO/RP-1/pull/2753).