### PR TITLE
Correct crewed lunar landing targets

### DIFF
--- a/GameData/RP-1/Contracts/Lunar Crewed/CrewedMoonLandingTargeted.cfg
+++ b/GameData/RP-1/Contracts/Lunar Crewed/CrewedMoonLandingTargeted.cfg
@@ -89,9 +89,10 @@ CONTRACT_TYPE
 		cb = Moon
 		title = The Moon
 	}
-	
+
+	// these coordinates are of apollo descent stages (hence why lat13 & long13 are missing). coordinates from https://en.wikipedia.org/wiki/List_of_artificial_objects_on_the_Moon
 	DATA
-	{ // the coordinates are of apollo descent stages (hence why lat13 & long13 are missing). coordinates from https://en.wikipedia.org/wiki/List_of_artificial_objects_on_the_Moon
+	{
 		type = double
 		lat11 = 0.67
 		long11 = 23.47

--- a/GameData/RP-1/Contracts/Lunar Crewed/CrewedMoonLandingTargeted.cfg
+++ b/GameData/RP-1/Contracts/Lunar Crewed/CrewedMoonLandingTargeted.cfg
@@ -91,36 +91,36 @@ CONTRACT_TYPE
 	}
 	
 	DATA
-	{
+	{ // the coordinates are of apollo descent stages (hence why lat13 & long13 are missing). coordinates from https://en.wikipedia.org/wiki/List_of_artificial_objects_on_the_Moon
 		type = double
-		lat11 = 0.41
-		long11 = 23.26
-		lat12 = -3.11
-		long12 = -23.23
-		lat14 = -3.40
-		long14 = -17.27
-		lat15 = 26.06
-		long15 = 3.39
-		lat16 = -8.59
-		long16 = 15.30
-		lat17 = 29.95
-		long17 = 30.45
+		lat11 = 0.67
+		long11 = 23.47
+		lat12 = -3.01
+		long12 = -23.42
+		lat14 = -3.65
+		long14 = -17.47
+		lat15 = 26.13
+		long15 = 3.63
+		lat16 = -8.97
+		long16 = 15.50
+		lat17 = 20.19
+		long17 = 30.77
 	}
 
 	DATA
 	{
 		type = string
-		String11 = 0.41° North, 23.26° East
+		String11 = 0.67° North, 23.47° East
 		//String12 = @/lat12.ToString("N2")"° South, "@/long12.ToString("N2")"° West"
-		String12 = 3.11° South, 23.23° West
+		String12 = 3.01° South, 23.42° West
 		//String14 = @/lat14.ToString("N2")"° South, "@/long14.ToString("N2")"° West"
-		String14 = 3.40° South, 17.27° West
+		String14 = 3.65° South, 17.47° West
 		//String15 = @/lat15.ToString("N2")"° North, "@/long15.ToString("N2")"° East"
-		String15 = 26.06° North, 3.39° East
+		String15 = 26.13° North, 3.63° East
 		//String16 = @/lat16.ToString("N2")"° South, "@/long16.ToString("N2")"° East"
-		String16 = 8.59° South, 15.30° East
+		String16 = 8.97° South, 15.50° East
 		//String17 = @/lat17.ToString("N2")"° North, "@/long17.ToString("N2")"° East"
-		String17 = 29.95° North, 30.45° East
+		String17 = 20.19° North, 30.77° East
 		hidden = true
 	}
 	


### PR DESCRIPTION
Fix https://github.com/KSP-RO/RP-1/issues/2778

The previous coordinates seem to have been the unconverted DMS coordinates. The Apollo 17 latitude was also just completely wrong, not sure what happened there

Sources from https://en.wikipedia.org/wiki/List_of_artificial_objects_on_the_Moon (which also lines up with the source from https://github.com/KSP-RO/RP-1/issues/2778#issuecomment-4416716958, although interestingly the apollo 17 longitude is slightly different, (30.7655 vs 30.7717) but both round to 30.77)