### PR TITLE
Fix the VesselBuiltAt parameter incorrectly allowing decoupled crafts

### DIFF
--- a/Source/CC_RP0/Parameter/VesselBuiltAt.cs
+++ b/Source/CC_RP0/Parameter/VesselBuiltAt.cs
@@ -39,8 +39,7 @@ namespace ContractConfigurator.RP0
         protected override bool VesselMeetsCondition(Vessel vessel)
         {
             EditorFacility? curBuiltAt = vessel.GetVesselBuiltAt();
-            return !curBuiltAt.HasValue || curBuiltAt.Value == builtAt ||
-                curBuiltAt.Value == EditorFacility.None;    // Build times disabled
+            return curBuiltAt.HasValue && curBuiltAt.Value == builtAt;
         }
     }
 }

--- a/Source/CC_RP0/Parameter/VesselBuiltAt.cs
+++ b/Source/CC_RP0/Parameter/VesselBuiltAt.cs
@@ -38,7 +38,7 @@ namespace ContractConfigurator.RP0
 
         protected override bool VesselMeetsCondition(Vessel vessel)
         {
-            if (PresetManager.Instance?.ActivePreset.GeneralSettings.Enabled == false) return true; // If build times are disabled, we cannot tell where the vessel was built, so we'll be nice.
+            if (PresetManager.Instance?.ActivePreset?.GeneralSettings.Enabled != true) return true; // If build times are disabled, we cannot tell where the vessel was built, so we'll be nice.
 
             EditorFacility? curBuiltAt = vessel.GetVesselBuiltAt();
             return curBuiltAt.HasValue && curBuiltAt.Value == builtAt;

--- a/Source/CC_RP0/Parameter/VesselBuiltAt.cs
+++ b/Source/CC_RP0/Parameter/VesselBuiltAt.cs
@@ -38,7 +38,7 @@ namespace ContractConfigurator.RP0
 
         protected override bool VesselMeetsCondition(Vessel vessel)
         {
-            if (KCT_GUI.IsPrimarilyDisabled) return true; // If build times are disabled, we cannot tell where the vessel was built, so we'll be nice.
+            if (PresetManager.Instance?.ActivePreset.GeneralSettings.Enabled == false) return true; // If build times are disabled, we cannot tell where the vessel was built, so we'll be nice.
 
             EditorFacility? curBuiltAt = vessel.GetVesselBuiltAt();
             return curBuiltAt.HasValue && curBuiltAt.Value == builtAt;

--- a/Source/CC_RP0/Parameter/VesselBuiltAt.cs
+++ b/Source/CC_RP0/Parameter/VesselBuiltAt.cs
@@ -38,6 +38,8 @@ namespace ContractConfigurator.RP0
 
         protected override bool VesselMeetsCondition(Vessel vessel)
         {
+            if (KCT_GUI.IsPrimarilyDisabled) return true;
+
             EditorFacility? curBuiltAt = vessel.GetVesselBuiltAt();
             return curBuiltAt.HasValue && curBuiltAt.Value == builtAt;
         }

--- a/Source/CC_RP0/Parameter/VesselBuiltAt.cs
+++ b/Source/CC_RP0/Parameter/VesselBuiltAt.cs
@@ -38,7 +38,7 @@ namespace ContractConfigurator.RP0
 
         protected override bool VesselMeetsCondition(Vessel vessel)
         {
-            if (KCT_GUI.IsPrimarilyDisabled) return true;
+            if (KCT_GUI.IsPrimarilyDisabled) return true; // If build times are disabled, we cannot tell where the vessel was built, so we'll be nice.
 
             EditorFacility? curBuiltAt = vessel.GetVesselBuiltAt();
             return curBuiltAt.HasValue && curBuiltAt.Value == builtAt;


### PR DESCRIPTION
This resolves an issue where VesselBuiltAt would incorrectly complete for vessels that are detached from other vessels. (And possibly also resolves the issue where EVA'd kerbals complete the parameter.)

Newly decoupled crafts would momentarily have no KCTVesselTracker, since KCTVesselTrackerEventHandler only copies over on onPartDeCoupleNewVesselComplete. Since VesselParameter re-checks on onPartDeCouple, it would note that the newly decoupled vessel has no KCTVesselTracker and therefore no FacilityBuiltAt, and flag the parameter as complete.

As far as I can tell, the old comment that checks for an empty EditorFacility if build times were disabled is slightly inaccurate, as it is empty if KCT is entirely disabled, not just build times. This case is still bugged...