### PR TITLE
Fix slot number warning in admin overlay

### DIFF
--- a/Source/RP0/Programs/ProgramStrategy.cs
+++ b/Source/RP0/Programs/ProgramStrategy.cs
@@ -118,16 +118,10 @@ namespace RP0.Programs
             int freeSlots = ProgramHandler.Instance.MaxProgramSlots - ProgramHandler.Instance.ActiveProgramSlots;
             if (_program.slots > freeSlots)
             {
-                if (freeSlots > 1)
-                {
-                    reason = $"This program requires {_program.slots} free slots but only {freeSlots} slots are available.";
-                    return false;
-                }
-                else
-                {
-                    reason = $"This program requires {_program.slots} free slots but only 1 slot is available.";
-                    return false;
-                }
+                reason = (freeSlots == 1)
+                    ? $"This program requires {_program.slots} free slots but only {freeSlots} slots are available.";
+                    : $"This program requires {_program.slots} free slots but only 1 slot is available.";
+                return false;
             }
 
             return true;

--- a/Source/RP0/Programs/ProgramStrategy.cs
+++ b/Source/RP0/Programs/ProgramStrategy.cs
@@ -118,7 +118,7 @@ namespace RP0.Programs
             int freeSlots = ProgramHandler.Instance.MaxProgramSlots - ProgramHandler.Instance.ActiveProgramSlots;
             if (_program.slots > freeSlots)
             {
-                reason = (freeSlots == 1)
+                reason = (freeSlots != 1)
                     ? $"This program requires {_program.slots} free slots but only {freeSlots} slots are available.";
                     : $"This program requires {_program.slots} free slots but only 1 slot is available.";
                 return false;


### PR DESCRIPTION
Selecting a program you cannot take due to insufficient slots in admin prints a warning at the top of the program page: "This program requires X slots but only Y are available". In the case where Y=0, this message used to incorrectly print Y=1 due to faulty logic.

