### PR TITLE
Loosen OPF Jupiter Flyby distance requirement

### DIFF
--- a/GameData/RP-1/Contracts/Outer Planet Flyby/Jupiter Flyby.cfg
+++ b/GameData/RP-1/Contracts/Outer Planet Flyby/Jupiter Flyby.cfg
@@ -71,9 +71,9 @@ CONTRACT_TYPE
 		{
 			name = FlybyPlanet
 			type = ReachState
-			maxAltitude = 150000000
+			maxAltitude = 400000000
 			disableOnStateChange = true
-			title = Flyby Jupiter within 150,000 km
+			title = Flyby Jupiter within 400,000 km
 			hideChildren = true
 		}
 		PARAMETER


### PR DESCRIPTION
The Outer Planet Flyby Jupiter flyby contract mandates a flyby of less than 150Mm, which does match the Pioneer flyby but not the Voyager ones. 